### PR TITLE
ci(dependabot): group github-actions updates into one pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,7 @@ updates:
     labels: ["dependencies", "github-actions"]
     commit-message:
       prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Ungrouped, Dependabot opens **one pull request per action**. For a multi-part action that is not a style preference — it is a broken build.

`github/codeql-action` is the case that surfaced this. CodeQL requires every `codeql-action/*` step in a run to be the same version, so a split bump fails on both halves:

```
##[error]Loaded a configuration file for version '4.37.6', but running version '4.37.4'
```

`init` and `analyze` usually sit in the same workflow file, so neither pull request can pass alone, and re-running never helps.

The pattern held exactly across the fleet: every repository **with** a `groups:` key had green CodeQL bumps; every repository **without** one had them split and failing. This adds the wildcard group already used by `camt053` and the other grouped repositories:

```yaml
    groups:
      github-actions:
        patterns:
          - "*"
```

Configuration only — no workflow or dependency versions change here.
