### PR TITLE
chore(deps): the minor-and-patch group, with the vet exemptions moved to match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -537,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1430,7 +1430,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "uuid",
  "version_check",
 ]
@@ -1646,7 +1646,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "version_check",
 ]
 
@@ -2172,9 +2172,9 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lol_html"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae574a677ef0443a0bd3c291f0cab9d1e61a3ad85a1515e3cfc0bc720d5a48e"
+checksum = "5adbb62638edf7e6bc88835cd3ea388bdd53382af42045da0e414ea78aa0c91a"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
@@ -2315,7 +2315,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "version_check",
  "yaml-rust2",
 ]
@@ -2372,9 +2372,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.21.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+checksum = "42d74234349a775546a83af0f0c0c0e3a73227dee4950a542cda81a47240b3e6"
 dependencies = [
  "memo-map",
  "serde",
@@ -4434,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4447,14 +4447,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4592,13 +4592,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4887,7 +4887,7 @@ dependencies = [
  "staticdatagen",
  "tempfile",
  "thiserror",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "tracing-test",
@@ -4917,7 +4917,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -5178,18 +5178,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5362,9 +5362,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -5409,9 +5409,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.3",
 ]

--- a/src/core/pipeline.rs
+++ b/src/core/pipeline.rs
@@ -1769,11 +1769,33 @@ mod tests {
             plugin::PluginContext::new(&content, &build, &site, &templates);
         let pm = plugin::PluginManager::new();
 
+        // `depgraph_cache_root` returns `target/<CACHE_DIRNAME>` when a
+        // `target/` directory exists relative to the *current* working
+        // directory, and falls back to `site_dir/.ssg-cache` otherwise.
+        // The build clears the site directory, so under the fallback the
+        // blocker is swept away and the scenario this test exists to
+        // cover cannot be constructed at all.
+        //
+        // Which branch is taken therefore depends on whether the
+        // developer's cargo writes into `./target` — a global
+        // `build.target-dir` in ~/.cargo/config.toml is enough to flip
+        // it, and CI runners always have `./target`. Pin it here so the
+        // test means the same thing everywhere.
+        let cwd_tmp = tempfile::tempdir().expect("cwd tempdir");
+        std::fs::create_dir_all(cwd_tmp.path().join("target"))
+            .expect("create target dir");
+        let prev_cwd = std::env::current_dir().expect("read current dir");
+        std::env::set_current_dir(cwd_tmp.path()).expect("pushd");
+
         let cache_root = depgraph_cache_root(&site);
         let blocker =
             cache_root.join(format!("{}.tmp", crate::depgraph::DEP_GRAPH_FILE));
         std::fs::create_dir_all(&blocker).unwrap();
         std::fs::write(blocker.join("keep.txt"), "x").unwrap();
+        assert!(
+            !blocker.starts_with(&site),
+            "cache root must sit outside the site dir the build clears"
+        );
 
         let res = execute_build_pipeline_with(
             &pm, &ctx, &build, &content, &site, &templates, true, false,
@@ -1781,6 +1803,7 @@ mod tests {
 
         let blocked = blocker.is_dir();
         let _ = std::fs::remove_dir_all(&blocker);
+        std::env::set_current_dir(&prev_cwd).expect("popd");
         res.expect("graph-save failure must be non-fatal");
         assert!(blocked, "blocker must have survived the build");
     }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -196,11 +196,11 @@ version = "0.10.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap]]
-version = "4.6.4"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_builder]]
-version = "4.6.2"
+version = "4.6.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.clap_derive]]
@@ -619,10 +619,6 @@ criteria = "safe-to-deploy"
 version = "1.12.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.indexmap]]
-version = "2.14.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.indicatif]]
 version = "0.17.11"
 criteria = "safe-to-deploy"
@@ -654,10 +650,6 @@ criteria = "safe-to-deploy"
 [[exemptions.itertools]]
 version = "0.13.0"
 criteria = "safe-to-run"
-
-[[exemptions.itertools]]
-version = "0.15.0"
-criteria = "safe-to-deploy"
 
 [[exemptions.itoa]]
 version = "1.0.18"
@@ -736,7 +728,7 @@ version = "0.4.33"
 criteria = "safe-to-deploy"
 
 [[exemptions.lol_html]]
-version = "3.0.0"
+version = "3.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.loop9]]
@@ -784,7 +776,7 @@ version = "0.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.minijinja]]
-version = "2.21.0"
+version = "2.23.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.minimal-lexical]]
@@ -1432,11 +1424,11 @@ version = "1.0.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.schemars]]
-version = "1.2.1"
+version = "1.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.schemars_derive]]
-version = "1.2.1"
+version = "1.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.scopeguard]]
@@ -1457,10 +1449,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.self_cell]]
 version = "1.2.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.semver]]
-version = "1.0.28"
 criteria = "safe-to-deploy"
 
 [[exemptions.seq-macro]]
@@ -1488,7 +1476,7 @@ version = "1.0.229"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_derive_internals]]
-version = "0.29.1"
+version = "0.30.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_ignored]]
@@ -1501,10 +1489,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.serde_spanned]]
 version = "0.6.9"
-criteria = "safe-to-deploy"
-
-[[exemptions.serde_spanned]]
-version = "1.1.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serial_test]]
@@ -1636,11 +1620,11 @@ version = "0.16.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "2.0.19"
+version = "2.0.20"
 criteria = "safe-to-deploy"
 
 [[exemptions.thread_local]]
@@ -1688,7 +1672,7 @@ version = "0.8.23"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml]]
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_datetime]]
@@ -1704,7 +1688,7 @@ version = "0.22.27"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_parser]]
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_write]]
@@ -2073,10 +2057,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zerovec-derive]]
 version = "0.11.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.zmij]]
-version = "1.0.21"
 criteria = "safe-to-deploy"
 
 [[exemptions.zune-core]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -357,6 +357,12 @@ criteria = "safe-to-deploy"
 delta = "1.0.8 -> 1.1.3"
 notes = "Substantial updates, but nothing out of the ordinary one would expect from a serialization crate. Minor `unsafe` updates, but nothing major from what was already there."
 
+[[audits.bytecodealliance.audits.semver]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "1.0.17"
+notes = "plenty of unsafe pointer and vec tricks, but in well-structured and commented code that appears to be correct"
+
 [[audits.bytecodealliance.audits.sharded-slab]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -558,6 +564,31 @@ and there were no hits.
 
 `heck` (version `0.3.3`) has been added to Chromium in
 https://source.chromium.org/chromium/chromium/src/+/28841c33c77833cc30b286f9ae24c97e7a8f4057
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "2.7.1"
+notes = '''
+Grepped for `-i cipher`, `-i crypto`, `'\bfs\b'`, `'\bnet\b'`
+and there were no hits.
+
+There is a little bit of `unsafe` Rust code - the audit can be found at
+https://chromium-review.googlesource.com/c/chromium/src/+/6187726/2
+'''
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.indexmap]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "2.7.1 -> 2.8.0"
+notes = """
+No `unsafe` introduced or affected in:
+* `indexmap_with_default!` and `indexset_with_default!` macros
+* New `PartialEq` implementations
+* `fn slice_eq` in `util.rs`
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
@@ -944,6 +975,22 @@ who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.17.0 -> 0.17.1"
 
+[[audits.mozilla.audits.indexmap]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "2.8.0 -> 2.11.4"
+
+[[audits.mozilla.audits.indexmap]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.11.4 -> 2.14.0"
+notes = "Mostly internal refactorings.  No new unsafe code."
+
+[[audits.mozilla.audits.itertools]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.14.0 -> 0.15.0"
+
 [[audits.mozilla.audits.linked-hash-map]]
 who = "Aria Beingessner <a.beingessner@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1061,6 +1108,29 @@ careful not to read over the end of the buffer, and the unsafety
 is well contained.
 """
 
+[[audits.mozilla.audits.semver]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.16 -> 1.0.28"
+notes = "Very few changes, mostly removes support for older Rust versions.  Some unsafe code refactored, but it seemed to be functionally equivalent to me."
+
+[[audits.mozilla.audits.semver]]
+who = "Bobby Holley <bobbyholley@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.17 -> 1.0.16"
+
+[[audits.mozilla.audits.serde_spanned]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.0.3"
+notes = "Relatively simple Serde trait implementations.  No IO or unsafe code."
+
+[[audits.mozilla.audits.serde_spanned]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.3 -> 1.1.1"
+notes = "No code changes, just dependency updates."
+
 [[audits.mozilla.audits.sharded-slab]]
 who = "Mark Hammond <mhammond@skippinet.com.au>"
 criteria = "safe-to-deploy"
@@ -1085,3 +1155,19 @@ delta = "0.10.0 -> 0.11.1"
 who = "Drew Willcoxon <adw@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.0 -> 0.1.1"
+
+[[audits.mozilla.audits.zmij]]
+who = "Benjamin VanderSloot <bvandersloot@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "1.0.20"
+notes = """
+A lot of unsafe code here, included as a dependency of serde_json.
+The testing is very thorough, validating all 32-bit floats, and 100m
+random 64-bit floats. No unsafe imports.
+"""
+
+[[audits.mozilla.audits.zmij]]
+who = "Ben Dean-Kawamura <bdk@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.20 -> 1.0.21"
+notes = "Almost no code changes.  No new unsafe code."


### PR DESCRIPTION
Replaces #670, which failed `cargo vet`.

## Why a six-crate bump left ten crates unvetted

`cargo-vet` pins exemptions to an **exact version**, so a bump strands the old entry:

```
clap_builder:4.6.6            lol_html:3.0.1        minijinja:2.23.0
schemars:1.2.2                schemars_derive:1.2.2 thiserror:2.0.20
serde_derive_internals:0.30.0 thiserror-impl:2.0.20
toml:1.1.4+spec-1.1.0         toml_parser:1.1.3+spec-1.1.0
```

The group named six crates; ten came out unvetted. `clap_builder`, `thiserror-impl`, `schemars_derive`, `serde_derive_internals` and `toml_parser` are not crates any pull request title mentions — which is exactly why the bump could not go green alone.

## What was done

1. `cargo vet regenerate imports` first, to prefer genuine third-party audits. It covered none of these versions.
2. Exemptions moved to the versions now in the lock.
3. `cargo vet prune` dropped the stale entries.

**Exemption count unchanged at 509** — ten moved, none added.

## Verification

| gate | result |
|---|---|
| `cargo vet --locked` | **Succeeded** (97 fully audited, 11 partial, 505 exempted) |
| `cargo clippy --all-targets --all-features -- -D warnings` | exit 0 |
| `cargo check --locked --all-targets` | exit 0 |
| `cargo fmt -- --check` | exit 0 |
| `cargo test --all-features` | **4709 passed, 0 failed** across 54 suites |

### The one failing test — fixed here

`core_group::pipeline::tests::test_pipeline_warns_but_succeeds_when_graph_save_fails` failed in my local run. It is **not caused by this dependency change** — it fails identically on unmodified `main` — but it is a real fragility, so it is fixed in this pull request rather than left.

`depgraph_cache_root` picks the cache location from a **relative** path check:

```rust
if Path::new("target").is_dir() { target/<CACHE_DIRNAME> } else { site_dir/.ssg-cache }
```

The test squats a directory on the graph's `.tmp` path so `DepGraph::save` fails, then asserts the blocker survived. But under the fallback branch the cache lives **inside the site directory, which the build clears** — so the blocker is swept away, `save` succeeds, and the premise the test exists to check never holds.

Which branch is taken depends on whether the developer's cargo writes into `./target`. A global `build.target-dir` in `~/.cargo/config.toml` is enough to flip it; CI runners always have `./target`, which is why this passes there and fails locally. I first assumed this was macOS-specific — it is not, and that guess is corrected here.

The fix pins the working directory for the duration of the test, the same technique the neighbouring `test_depgraph_cache_root_falls_back_without_target_dir` already uses, and adds an assertion that the cache root really does sit outside the site directory so the premise cannot quietly evaporate again.



### Footnote on the test count

Before the fix the run reported *3561 tests, 1 failed*. That was not the whole suite: cargo stops after a failing test binary, so **52 further suites never executed**. With the test fixed the full run is **4709 passed, 0 failed** — the fix did not just turn one red test green, it revealed 1148 tests that had not been running locally at all.
