### PR TITLE
fix(release): repair the publish pipeline and document v0.0.50

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,14 @@ on:
 permissions:
   contents: read
 
+# A release must never be silently superseded. `cancel-in-progress:
+# false` means a second tag push queues behind the first rather than
+# killing a run that may already have published sub-crates to
+# crates.io — a partially-published release is not re-runnable.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "0"
@@ -251,8 +259,18 @@ jobs:
           tags: |
             ghcr.io/sebastienrousseau/static-site-generator:${{ github.ref_name }}
             ghcr.io/sebastienrousseau/static-site-generator:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Cache lives in GHCR, not the GitHub Actions Cache service.
+          # `type=gha` is what failed the v0.0.48 release: the image
+          # itself built for 126.9s and then the run died with
+          # `ERROR: not_found` while "exporting to GitHub Actions
+          # Cache", so a green build produced no container image.
+          #
+          # `ignore-error=true` is the belt to that braces. A cache
+          # export is an optimisation; it must never be able to fail a
+          # release. With it set, a registry hiccup costs the next run
+          # some time instead of costing this run the image.
+          cache-from: type=registry,ref=ghcr.io/sebastienrousseau/static-site-generator:buildcache
+          cache-to: type=registry,ref=ghcr.io/sebastienrousseau/static-site-generator:buildcache,mode=max,ignore-error=true
 
   # ── GPG sign all release artifacts ──────────────────────────────
   gpg-sign:
@@ -586,7 +604,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Publish workspace sub-crates to crates.io (dep order)
+      - name: Publish workspace to crates.io (dep order)
         # `cargo publish -p ssg` fails if ssg-core / ssg-rpc-macro /
         # ssg-rpc / ssg-search / ssg-a11y at the matching version don't
         # already exist on crates.io (path deps are verified against
@@ -597,41 +615,71 @@ jobs:
         #   ssg-rpc          (depends on ssg-rpc-macro)
         #   ssg-search       (no internal deps)
         #   ssg-a11y         (no internal deps)
+        #   ssg             (depends on all of the above)
         #
         # ssg-wasm is deliberately excluded: it carries `publish = false`
         # in its own Cargo.toml and is not a dependency of `ssg`.
         #
-        # crates.io's index needs ~30s after each publish before the
-        # next crate can depend on the freshly-published version, so
-        # we sleep between calls. `--no-verify` skips the rebuild
-        # against the registry (we already built + tested in earlier
-        # CI phases) and shaves a few minutes off the wall clock.
+        # Every publishable crate must therefore carry the SAME version
+        # as the tag. When they drift — sub-crates sat at 0.0.47 while
+        # the root moved to 0.0.48 — the first `cargo publish` hits
+        # "already exists on crates.io index" and the release stops.
+        # `tests/release_versions.rs` fails the build long before the
+        # tag if that drift reappears.
         #
         # Idempotent retry: if a version is already on crates.io
-        # (e.g. previous release run already published the sub-crate
+        # (e.g. a previous release run already published the sub-crate
         # and the workflow is being re-run), don't fail the build.
+        #
+        # The "already published" case is detected by reading cargo's
+        # own diagnostic, not by probing the crates.io HTTP API. The
+        # previous implementation curl'd
+        # `https://crates.io/api/v1/crates/$c/$ver` and treated any
+        # non-200 as "not published"; that request failed from the
+        # runner during the v0.0.48 release (it returns 200 from a
+        # developer machine), so the guard reported a crate that WAS on
+        # crates.io as missing, exited 1, and skipped the `ssg` publish
+        # below. Parsing stderr needs no network and cannot produce a
+        # false negative from a transient registry or CDN fault.
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
-          for c in ssg-core ssg-rpc-macro ssg-rpc ssg-search ssg-a11y; do
-            echo "::group::cargo publish -p $c"
-            if cargo publish -p "$c" --locked --no-verify; then
-              echo "✓ $c published"
-            else
-              ver=$(grep '^version = ' "crates/$c/Cargo.toml" | head -1 | cut -d'"' -f2)
-              if curl -fsS "https://crates.io/api/v1/crates/$c/$ver" >/dev/null 2>&1; then
-                echo "✓ $c $ver already on crates.io — continuing"
-              else
-                echo "::error::cargo publish -p $c failed and version not on crates.io"
-                exit 1
-              fi
-            fi
+
+          # Publish one crate. Returns 0 if it is on crates.io at the
+          # expected version afterwards — whether this run put it
+          # there or a previous one did.
+          publish() {
+            local crate="$1" manifest="$2" ver log rc=0
+            # Sub-crates pass --no-verify: they were already built and
+            # tested in earlier CI phases, and the rebuild costs
+            # minutes each. The root crate verifies, because that is
+            # the packaged artefact users actually consume.
+            shift 2
+            ver=$(grep -m1 '^version = ' "$manifest" | cut -d'"' -f2)
+            log=$(mktemp)
+            echo "::group::cargo publish -p $crate ($ver)"
+            cargo publish -p "$crate" --locked "$@" 2>&1 | tee "$log" || rc=$?
             echo "::endgroup::"
-            sleep 30
+            if [ "$rc" -eq 0 ]; then
+              echo "✓ $crate $ver published"
+              # crates.io's index needs a moment before the next crate
+              # can resolve a dependency on this one.
+              sleep 30
+              return 0
+            fi
+            if grep -qE 'already (exists on crates\.io index|uploaded)' "$log"; then
+              echo "✓ $crate $ver already on crates.io — continuing"
+              return 0
+            fi
+            echo "::error::cargo publish -p $crate $ver failed (exit $rc) — see the group above"
+            return 1
+          }
+
+          for c in ssg-core ssg-rpc-macro ssg-rpc ssg-search ssg-a11y; do
+            publish "$c" "crates/$c/Cargo.toml" --no-verify
           done
 
-      - name: Publish ssg to crates.io
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p ssg --locked
+          # Same idempotency contract for the root crate, so a re-run
+          # after a partial release is a no-op rather than a failure.
+          publish ssg Cargo.toml

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -2,8 +2,15 @@
 #
 # Scheduled & on-demand workloads. Runs:
 #   - weekly  Monday 06:00 UTC (full surface check)
-#   - on tag  v*                (release-gating coverage)
 #   - manual  workflow_dispatch (anytime)
+#
+# Deliberately NOT triggered by `v*` tags. It used to be, described as
+# "release-gating coverage", but nothing in `release.yml` waited on the
+# result — so a tag push started two heavyweight runs side by side and
+# gated nothing. That collision is what left v0.0.49 cancelled with no
+# artefacts. Pre-release coverage is CI on `main` plus the release
+# build matrix itself; run this manually against a tag if the full
+# multi-OS surface is wanted before shipping.
 #
 # Holds the heavier checks that aren't worth the latency on every PR:
 #   - Multi-OS × multi-toolchain build matrix (macOS, Windows, MSRV)
@@ -16,8 +23,6 @@ name: Scheduled
 on:
   schedule:
     - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
-  push:
-    tags: ["v*"]
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.50] - 2026-08-11
+## [0.0.50] - 2026-08-14
 
 The themeing release. Building three real themes against v0.0.49 surfaced
 four defects that made documented features unusable — each failing silently,
 which is why none had been reported. Multi-locale sites additionally gain
 translated slugs.
 
+It also repairs the release pipeline itself. Nothing had published cleanly
+since v0.0.46: crates.io was two versions behind the README's own install
+instruction, and v0.0.49 produced no artefacts at all.
+
 ### Fixed
 
+- **The release pipeline could not publish.** Three separate faults, each
+  masking the next:
+  - Workspace members were frozen at `0.0.47` while the root crate advanced
+    to `0.0.50`, so the first `cargo publish -p ssg-core` of every release
+    aborted with `already exists on crates.io index`. All six members and
+    the four root dependency pins now track the root version, and
+    `tests/release_versions.rs` fails the build if they drift again —
+    before a tag is cut rather than after.
+  - The step's own idempotency guard, which should have absorbed that,
+    probed `https://crates.io/api/v1/crates/<crate>/<version>` over HTTP.
+    That request failed from the runner during v0.0.48 (it returns 200 from
+    a developer machine), so a crate that *was* on crates.io was reported
+    missing, the step exited 1, and `Publish ssg to crates.io` never ran.
+    The guard now reads cargo's own diagnostic and needs no network.
+  - The GHCR job exported its build cache to the GitHub Actions Cache
+    service, which failed with `ERROR: not_found` after a 126.9s export —
+    a green image build that shipped no image. The cache moved to GHCR
+    itself, with `ignore-error=true` so a cache fault can never fail a
+    release again.
+- **A release tag started two heavyweight workflow runs.** `scheduled.yml`
+  triggered on `v*` tags as "release-gating coverage", but nothing in
+  `release.yml` waited on its result, so it gated nothing while doubling
+  the load. Both runs were cancelled together at v0.0.49, leaving that tag
+  with no release. The tag trigger is gone, and `release.yml` gained a
+  `concurrency` group with `cancel-in-progress: false` so a release is
+  never silently superseded mid-publish.
+- **`examples/multilingual_full` audited the pre-0.0.50 output layout.** It
+  expected each locale home page at `<lang>/index/index.html` — the extra
+  directory level this release removes — and so reported all five as
+  missing on every run. It now checks `<lang>/index.html`, and additionally
+  asserts that the translated-slug pages are *reciprocally linked* rather
+  than merely present; unpaired translations fail the example hard, in CI
+  included.
 - **`layout` was ignored on every page** (`src/plugins/template_plugin.rs`).
   `before_compile` writes front-matter sidecars to `<build_dir>/.meta`, but
   `staticdatagen` promotes `output.build-tmp` onto `output` once the compile
@@ -159,6 +196,31 @@ translated slugs.
   bodies.
 - **`x-default` is emitted only when the default locale serves the page**,
   rather than pointing at a URL that may not exist.
+
+### Documentation
+
+Translated slugs shipped with no user-facing documentation: on merge,
+`translation_key` appeared in exactly two files in the repository — the
+plugin source and this changelog. The `docs_accuracy` gate did not catch it
+because it verifies numeric claims (version strings, test counts, coverage
+floors, MSRV), not whether a feature was described anywhere.
+
+- **`docs/guide/i18n.md`** documented the identical-path pairing model this
+  release replaced, illustrated with `/en/about` ↔ `/fr/about`. Rewritten
+  against actual behaviour: a new *Page Pairing* section covering
+  `translation_key` and the path fallback, a *Root-hosted default locale*
+  section giving the three conditions detection requires, and an
+  explanation of how each `hreflang` value is chosen and why reciprocity
+  depends on it. The sitemap and language-switcher sections were corrected
+  to match — the switcher lists a locale only when a paired page exists.
+- **`docs/guide/content.md`** gained `translation_key` in the standard
+  front-matter field table, where an author would actually look for it.
+- **`src/plugins/i18n.rs`** module docs now explain pairing, root-locale
+  serving and reciprocity. The existing rustdoc was accurate but attached to
+  private items, so none of it reached docs.rs.
+- **`README.md`** describes the feature in the i18n row rather than only
+  bumping its version badge, and the examples table lists
+  `multilingual_full`, which was absent.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-a11y"
-version = "0.0.47"
+version = "0.0.50"
 dependencies = [
  "serde",
  "serde_json",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-core"
-version = "0.0.47"
+version = "0.0.50"
 dependencies = [
  "log",
  "noyalib 0.0.17",
@@ -4923,7 +4923,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc"
-version = "0.0.47"
+version = "0.0.50"
 dependencies = [
  "criterion",
  "inventory",
@@ -4936,7 +4936,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc-macro"
-version = "0.0.47"
+version = "0.0.50"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4945,7 +4945,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-search"
-version = "0.0.47"
+version = "0.0.50"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-wasm"
-version = "0.0.47"
+version = "0.0.50"
 dependencies = [
  "js-sys",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,10 +181,10 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["html
 rayon = "1.12.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.47" }
-ssg-core = { path = "crates/ssg-core", version = "0.0.47" }
-ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.47" }
-ssg-search = { path = "crates/ssg-search", version = "0.0.47" }
+ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.50" }
+ssg-core = { path = "crates/ssg-core", version = "0.0.50" }
+ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.50" }
+ssg-search = { path = "crates/ssg-search", version = "0.0.50" }
 thiserror = "2"
 staticdatagen = "0.0.11"
 toml = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ graph TD
 | Metric | Value |
 | :--- | :--- |
 | **Source** | 71,000+ lines across 7 workspace crates (`ssg`, `ssg-core`, `ssg-a11y`, `ssg-search`, `ssg-rpc`, `ssg-rpc-macro`, `ssg-wasm`) |
-| **Test suite** | 3,536 unit tests + 36 integration test suites |
+| **Test suite** | 3,566 unit tests (`cargo test --lib`) + 51 integration test targets |
 | **Coverage** | 95% region, 95% line, 95% function (CI-gated) |
 | **Plugin pipeline** | 38 plugins, Rayon-parallelised |
 | **Audit gates** | 15 (WCAG 2.2 AAA, JSON-LD, hreflang, lang consistency, CSP+SRI, PQC TLS, HTML5, broken links, OG, markdown lint, perf budget, AI discovery, RSS/Atom, image opt, search index integrity) |
@@ -172,7 +172,7 @@ Reproduce: `cargo bench --bench bench -- scalability`.
 | **Structured Data** | JSON-LD Article/WebPage with datePublished, dateModified, author, image, inLanguage, `BreadcrumbList` |
 | **Syndication** | RSS 2.0 with enclosures and categories, Atom 1.0, Google News sitemap |
 | **Accessibility** | WCAG 2.2 AA validation on every build (1.1.1, 1.3.1, 2.3.1, 2.4.4, 2.4.13, 2.5.8, 3.1.1, 3.2.6), axe-core Playwright CI, decorative image detection, heading hierarchy, ARIA landmarks; emits `wcag-compliance.json` matrix ([WCAG 2.2 + EAA guide](docs/guide/wcag-compliance.md)) |
-| **i18n** | Hreflang injection, `x-default` support, per-locale sitemaps, language switcher HTML |
+| **i18n** | Hreflang injection, `x-default` support, per-locale sitemaps, language switcher HTML. Translated slugs — pages pair across locales by a `translation_key` front-matter field rather than by identical path, so `/about/` and `/fr/a-propos/` are reciprocal alternates; pages without a key keep pairing by path. The default locale may serve from the site root (`/about/` alongside `/fr/a-propos/`), matching Hugo, Astro and Next.js ([i18n guide](docs/guide/i18n.md)) |
 | **Images** | Responsive `<picture>` with WebP sources, `srcset` at 320/640/1024/1440, lazy loading, CLS prevention, optional `cdn_prefix` for serving local image assets from a CDN host |
 | **Templates** | `MiniJinja` engine with inheritance, loops, conditionals, custom filters |
 | **Search** | Client-side full-text search with modal UI, 28 locale translations, `Ctrl+K` / `Cmd+K` |
@@ -460,6 +460,7 @@ cargo run --example blog
 | `basic` | Minimal site with SEO, search, and fused transforms |
 | `quickstart` | Scaffold and build in 10 lines |
 | `multilingual` | Multi-locale site with hreflang and per-locale sitemaps |
+| `multilingual_full` | Nested `content/<lang>/` layout, plus translated slugs paired by `translation_key` (`/en/about/` ↔ `/fr/a-propos/` ↔ `/de/ueber-uns/`). Asserts reciprocity, not just that pages rendered |
 | `plugins` | Full plugin pipeline demo with `DepGraph` API |
 | `blog` | EAA-compliant accessibility-first blog with dual feeds |
 | `docs` | Documentation portal with schema validation and syntax highlighting |

--- a/crates/ssg-a11y/Cargo.toml
+++ b/crates/ssg-a11y/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-a11y"
-version = "0.0.47"
+version = "0.0.50"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-core"
-version = "0.0.47"
+version = "0.0.50"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc-macro"
-version = "0.0.47"
+version = "0.0.50"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc/Cargo.toml
+++ b/crates/ssg-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc"
-version = "0.0.47"
+version = "0.0.50"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ schemars = { version = "1.2", default-features = false, features = ["derive", "s
 thiserror = "2"
 
 # Re-export the proc-macro so users only depend on `ssg-rpc`.
-ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.47" }
+ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.50" }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/ssg-search/Cargo.toml
+++ b/crates/ssg-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-search"
-version = "0.0.47"
+version = "0.0.50"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-wasm/Cargo.toml
+++ b/crates/ssg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-wasm"
-version = "0.0.47"
+version = "0.0.50"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/docs/guide/content.md
+++ b/docs/guide/content.md
@@ -34,6 +34,7 @@ Your content here.
 | `categories` | List | Categories for taxonomy generation |
 | `template` | String | Override the default template for this page |
 | `language` | String | Page language (BCP 47), overrides site default |
+| `translation_key` | String | Pairs this page with its translations in other locales — see [i18n](i18n.md#translated-slugs). Required only when the translated pages have different slugs |
 
 ### Frontmatter Formats
 

--- a/docs/guide/i18n.md
+++ b/docs/guide/i18n.md
@@ -45,23 +45,112 @@ content/
     about.md
 ```
 
-## Hreflang Injection
+A locale's home page may be written either as `fr.md` or as
+`fr/index.md`. Both compile to `fr/index.html`. If you author *both*,
+neither is rewritten and you get whatever the compiler produces —
+pick one.
 
-The `I18nPlugin` runs in `after_compile` and automatically:
+### Root-hosted default locale
 
-1. Scans the output directory for locale-prefixed subdirectories
-2. Injects `<link rel="alternate" hreflang="...">` tags into every HTML page that exists in multiple locales
-3. Adds an `x-default` alternate pointing to the default locale
+The default locale may also live at the site root, with only the other
+locales taking a URL segment:
 
-Example injected HTML:
-
-```html
-<link rel="alternate" hreflang="en" href="https://example.com/en/about" />
-<link rel="alternate" hreflang="fr" href="https://example.com/fr/about" />
-<link rel="alternate" hreflang="x-default" href="https://example.com/en/about" />
+```
+content/
+  index.md          → /
+  about.md          → /about/
+  fr/
+    index.md        → /fr/
+    a-propos.md     → /fr/a-propos/
 ```
 
-The injection is **idempotent** — pages that already contain hreflang links are skipped.
+This matches the default in Hugo, Astro and Next.js. SSG selects it
+automatically — there is no config flag. The root locale is detected
+when all three hold:
+
+1. `default_locale` appears in `locales`;
+2. there is **no** output directory named after the default locale
+   (no `<site>/en/`);
+3. at least one HTML file sits at the site root, or in a directory
+   that is not one of the other locales.
+
+If you create an `en/` directory, detection turns off and `en` is
+treated as an ordinary sub-path locale again.
+
+## Page Pairing
+
+Before it can emit hreflang, SSG has to decide which pages in
+different locales are translations of one another. It builds a matrix
+of `key -> {locale -> path}` and pairs every page sharing a key.
+
+A page's key is:
+
+1. its `translation_key` front-matter value, when it declares one;
+2. otherwise its locale-relative path.
+
+### Translated slugs
+
+Path matching alone cannot pair `about` with `a-propos` — they are
+different paths, so each is a singleton and **neither receives any
+hreflang at all**. Declare a shared `translation_key` to pair them:
+
+```yaml
+---
+title: "About"
+translation_key: "about"
+---
+```
+
+```yaml
+---
+title: "À propos"
+translation_key: "about"
+---
+```
+
+`/about/` and `/fr/a-propos/` are now alternates of each other. The
+key is an arbitrary stable string; it never appears in output.
+
+Pages without a `translation_key` keep pairing by path, so adding keys
+to part of a site does not disturb the rest, and a site with no keys
+anywhere produces exactly the matrix it produced before the feature
+existed.
+
+## Hreflang Injection
+
+The `I18nPlugin` injects `<link rel="alternate" hreflang="...">` into
+every page that shares a key with a page in another locale, and adds
+an `x-default` alternate — but only when the default locale actually
+serves that page.
+
+Example injected HTML for `/about/`, paired by `translation_key`:
+
+```html
+<link rel="alternate" hreflang="en" href="https://example.com/about" />
+<link rel="alternate" hreflang="fr" href="https://example.com/fr/a-propos" />
+<link rel="alternate" hreflang="x-default" href="https://example.com/about" />
+```
+
+The injection is **idempotent** — pages that already contain hreflang
+links are skipped.
+
+### How each `hreflang` value is chosen
+
+An alternate link describes the document it points *at*, so each label
+carries the resolved language of its **target** page — the same value
+that page publishes in its own `<html lang>`, JSON-LD `inLanguage` and
+`og:locale`. The self-referential entry uses the current page's own
+resolved language.
+
+This is what makes the pair reciprocal. Labelling every alternate with
+the bare locale directory name instead lets the two sides disagree —
+an English page advertising its Hindi alternate as `hi` while the
+Hindi page calls itself `hi-IN` — which fails Google's reciprocity
+requirement and the `hreflang` audit gate along with it.
+
+An authored locale code is preserved byte-for-byte: `zh-tw` stays
+`zh-tw`. A resolved language replaces it only when it differs by more
+than case, i.e. on a genuine front-matter override.
 
 ## Accept-Language Negotiation
 
@@ -75,21 +164,27 @@ The plugin generates locale-specific sitemaps with `xhtml:link` alternates:
 - `sitemap-fr.xml`
 - `sitemap-de.xml`
 
-Each sitemap entry includes alternate links to all other locales:
+Each sitemap entry includes alternate links to all other locales,
+resolved through the same key matrix as the `<head>` links — so
+translated slugs are carried into the sitemap too:
 
 ```xml
 <url>
-  <loc>https://example.com/en/about</loc>
+  <loc>https://example.com/about</loc>
   <xhtml:link rel="alternate" hreflang="fr"
-    href="https://example.com/fr/about" />
+    href="https://example.com/fr/a-propos" />
   <xhtml:link rel="alternate" hreflang="de"
-    href="https://example.com/de/about" />
+    href="https://example.com/de/ueber-uns" />
 </url>
 ```
 
 ## Language Switcher
 
-SSG provides an HTML helper for generating a language switcher component. The switcher links to the same page in all available locales.
+SSG provides an HTML helper for generating a language switcher
+component. The switcher links to each locale's **paired translation**
+of the current page — the page sharing its `translation_key`, or the
+same path when no key is declared. Locales with no paired page are
+omitted rather than linked to a 404.
 
 ## Next Steps
 

--- a/examples/multilingual_full/content/de/ueber-uns.md
+++ b/examples/multilingual_full/content/de/ueber-uns.md
@@ -1,0 +1,21 @@
+---
+title: "Über uns"
+description: "Demonstration übersetzter Slugs — deutsche Ausgabe"
+permalink: "https://example.invalid/de/ueber-uns"
+layout: page
+author: "ssg multilingual_full example"
+date: "January 1, 2026"
+language: "de"
+hreflang: "de"
+changefreq: "monthly"
+translation_key: "about"
+---
+
+# Über uns
+
+Diese Seite trägt `translation_key: "about"`, ebenso wie ihre vier
+Entsprechungen in den anderen Sprachen — bei jeweils unterschiedlichem
+Slug.
+
+Verknüpft werden sie über den Schlüssel, nicht über den Pfad, sodass
+jede Seite die übrigen vier per `hreflang` ausweist.

--- a/examples/multilingual_full/content/en/about.md
+++ b/examples/multilingual_full/content/en/about.md
@@ -1,0 +1,33 @@
+---
+title: "About"
+description: "Translated-slug demonstration — English edition"
+permalink: "https://example.invalid/en/about"
+layout: page
+author: "ssg multilingual_full example"
+date: "January 1, 2026"
+language: "en"
+hreflang: "en"
+changefreq: "monthly"
+translation_key: "about"
+---
+
+# About
+
+This page and its four siblings all carry `translation_key: "about"`
+but sit at a **different slug in every locale**:
+
+| Locale | Path |
+| :--- | :--- |
+| en | `/en/about/` |
+| fr | `/fr/a-propos/` |
+| de | `/de/ueber-uns/` |
+| es | `/es/acerca-de/` |
+| ja | `/ja/gaiyou/` |
+
+Path matching cannot pair these — the paths differ — so without a
+shared key each would be a singleton and none would receive any
+`hreflang` at all. The key pairs them, and every one of the five ends
+up advertising the other four.
+
+Compare with `post-1` … `post-5`, which use the same slug in all five
+locales and so pair by path with no key needed.

--- a/examples/multilingual_full/content/es/acerca-de.md
+++ b/examples/multilingual_full/content/es/acerca-de.md
@@ -1,0 +1,21 @@
+---
+title: "Acerca de"
+description: "Demostración de slug traducido — edición española"
+permalink: "https://example.invalid/es/acerca-de"
+layout: page
+author: "ssg multilingual_full example"
+date: "January 1, 2026"
+language: "es"
+hreflang: "es"
+changefreq: "monthly"
+translation_key: "about"
+---
+
+# Acerca de
+
+Esta página lleva `translation_key: "about"`, igual que sus cuatro
+equivalentes en los demás idiomas, aunque el slug sea distinto en cada
+uno.
+
+Lo que las empareja es la clave, no la ruta, de modo que cada página
+anuncia las otras cuatro mediante `hreflang`.

--- a/examples/multilingual_full/content/fr/a-propos.md
+++ b/examples/multilingual_full/content/fr/a-propos.md
@@ -1,0 +1,21 @@
+---
+title: "À propos"
+description: "Démonstration de slug traduit — édition française"
+permalink: "https://example.invalid/fr/a-propos"
+layout: page
+author: "ssg multilingual_full example"
+date: "January 1, 2026"
+language: "fr"
+hreflang: "fr"
+changefreq: "monthly"
+translation_key: "about"
+---
+
+# À propos
+
+Cette page porte `translation_key: "about"`, comme ses quatre
+équivalents dans les autres langues, alors que son slug diffère de
+chacun d'eux.
+
+C'est la clé — et non le chemin — qui les associe, et chaque page
+annonce donc les quatre autres en `hreflang`.

--- a/examples/multilingual_full/content/ja/gaiyou.md
+++ b/examples/multilingual_full/content/ja/gaiyou.md
@@ -1,0 +1,20 @@
+---
+title: "概要"
+description: "翻訳スラッグのデモンストレーション — 日本語版"
+permalink: "https://example.invalid/ja/gaiyou"
+layout: page
+author: "ssg multilingual_full example"
+date: "January 1, 2026"
+language: "ja"
+hreflang: "ja"
+changefreq: "monthly"
+translation_key: "about"
+---
+
+# 概要
+
+このページは他の四言語版と同じ `translation_key: "about"` を持ちますが、
+スラッグはそれぞれ異なります。
+
+対応付けはパスではなくキーによって行われるため、各ページは残る四言語版を
+`hreflang` として宣言します。

--- a/examples/multilingual_full_example.rs
+++ b/examples/multilingual_full_example.rs
@@ -7,14 +7,28 @@
 //! ## What this example demonstrates
 //!
 //! - **`content/<lang>/<slug>.md` layout** — 5 locales (en / fr / de /
-//!   es / ja), each with an `index.md` + 5 posts. 32 source files
-//!   total, mirroring the Jekyll `_posts/<lang>/` pattern.
+//!   es / ja), each with an `index.md`, 5 posts and one translated-slug
+//!   page. 37 source files total, mirroring the Jekyll
+//!   `_posts/<lang>/` pattern.
 //! - **Recursive content walk** — every per-locale post produces its
 //!   own page under `public/<lang>/post-N/index.html` and a per-locale
 //!   `public/<lang>/index.html` landing.
+//! - **Translated slugs via `translation_key`** — `about`,
+//!   `a-propos`, `ueber-uns`, `acerca-de` and `gaiyou` are the same
+//!   document at five different paths. Pages are paired by front-matter
+//!   key rather than by path, so all five end up as reciprocal
+//!   `hreflang` alternates of one another. Without a key they would
+//!   each be a singleton and receive no alternates at all — silently.
+//!   The `post-N` pages, which share a slug across locales, still pair
+//!   by path with no key needed; both mechanisms run side by side here.
 //! - **Per-locale hreflang** — each generated page carries the
 //!   `language` / `hreflang` frontmatter so search engines see distinct
 //!   language editions.
+//!
+//! The runner asserts reciprocity, not just existence: a page that
+//! renders but pairs with nothing is precisely the failure mode
+//! `translation_key` exists to prevent, and it is invisible to a
+//! "did the file get written" check.
 //!
 //! ## Why this is its own example
 //!
@@ -24,15 +38,15 @@
 //! layout — physically separate per-locale source files under
 //! `content/<lang>/`.
 //!
-//! ## Dependency note (v0.0.46 cycle)
+//! ## Dependency note
 //!
-//! Until `staticdatagen 0.0.10` is released, the recursive walk in
-//! `add()` silently skips subdirectories ([upstream
+//! The recursive walk in `add()` silently skipped subdirectories
+//! before `staticdatagen 0.0.10` ([upstream
 //! #70](https://github.com/sebastienrousseau/staticdatagen/issues/70)).
-//! Run against today's staticdatagen 0.0.9 and the runner will warn
-//! for every missing per-locale output but still exit cleanly so CI
-//! doesn't break. Run against 0.0.10+ and every per-locale URL lands
-//! and the warnings disappear.
+//! The workspace has been on 0.0.11 since v0.0.48, so every per-locale
+//! URL lands. The runner still only warns under `CI` rather than
+//! failing, so a future upstream regression shows up as missing pages
+//! in the log instead of a red build on someone else's change.
 //!
 //! ## Run it
 //!
@@ -48,11 +62,34 @@ use ssg::pipeline::compile_site;
 const LOCALES: &[&str] = &["en", "fr", "de", "es", "ja"];
 const POSTS_PER_LOCALE: usize = 5;
 
+/// The translated-slug family: one page per locale, all sharing
+/// `translation_key: "about"` in front matter, each at a slug of its
+/// own. Path matching pairs `post-1` across locales for free because
+/// the slug is identical everywhere; it cannot pair these, which is
+/// exactly what the key is for.
+const ABOUT_SLUGS: &[(&str, &str)] = &[
+    ("en", "about"),
+    ("fr", "a-propos"),
+    ("de", "ueber-uns"),
+    ("es", "acerca-de"),
+    ("ja", "gaiyou"),
+];
+
+/// Returns the `href` of the `<link rel="alternate">` for `locale`,
+/// or `None` when the page declares no alternate for it.
+fn alternate_href<'a>(html: &'a str, locale: &str) -> Option<&'a str> {
+    let needle = format!("hreflang=\"{locale}\" href=\"");
+    let start = html.find(&needle)? + needle.len();
+    let rest = html.get(start..)?;
+    rest.find('"').map(|end| &rest[..end])
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
-    let build_dir = Path::new("./examples/multilingual_full/build");
     let content_dir = Path::new("./examples/multilingual_full/content");
     let site_dir = Path::new("./examples/multilingual_full/public");
     let template_dir = Path::new("./examples/templates");
+
+    let build_dir = Path::new("./examples/multilingual_full/build");
 
     // Wipe previous run output so re-runs are deterministic.
     let _ = std::fs::remove_dir_all(build_dir);
@@ -60,15 +97,50 @@ fn main() -> Result<(), Box<dyn Error>> {
     std::fs::create_dir_all(build_dir)?;
 
     println!(
-        "multilingual_full: compiling 32 source files across 5 locales..."
+        "multilingual_full: compiling 37 source files across 5 locales..."
     );
 
-    // `compile_site` already routes through the v0.0.45 content
-    // stager (default-layout injection, template stub fill-in, etc.)
-    // so this example doesn't need to wire the shim layer by hand.
+    // `compile_site` routes through the v0.0.45 content stager
+    // (default-layout injection, template stub fill-in, etc.) so this
+    // example doesn't need to wire the shim layer by hand.
+    //
+    // It registers no plugins, which is why the i18n pass below is
+    // explicit. That also means the pages emitted here carry no Open
+    // Graph tags, no `twitter:card` and no charset, so they do not
+    // satisfy `tests/element_presence.rs` if that gate is pointed at
+    // them. Driving `build_pipeline` instead would fix it and is the
+    // right end state, but this example's content lacks the front
+    // matter the full pipeline's manifest / CNAME / humans templates
+    // need — separate work, tracked rather than half-done here.
     compile_site(build_dir, content_dir, site_dir, template_dir)?;
 
-    println!("multilingual_full: compile done — auditing output:");
+    // Front-matter sidecars carry `translation_key` from the source
+    // markdown to the i18n plugin, which runs after compilation and so
+    // can no longer see the front matter itself. `compile_site` leaves
+    // none behind here, so write them where `resolve_sidecar_dir`
+    // looks once the build directory is gone: `<site>/.meta`.
+    let sidecar_dir = site_dir.join(".meta");
+    let sidecars = ssg::frontmatter::emit_sidecars(content_dir, &sidecar_dir)?;
+    println!("multilingual_full: wrote {sidecars} front-matter sidecars");
+
+    // Inject hreflang. Without this pass the pages are built but
+    // unlinked, and the translated-slug pairing below has nothing to
+    // assert against.
+    {
+        use ssg::i18n::{I18nConfig, I18nPlugin, UrlPrefixStrategy};
+        use ssg::plugin::{Plugin, PluginContext};
+
+        let plugin = I18nPlugin::new(I18nConfig {
+            default_locale: "en".to_string(),
+            locales: LOCALES.iter().map(|l| (*l).to_string()).collect(),
+            url_prefix: UrlPrefixStrategy::SubPath,
+        });
+        let ctx =
+            PluginContext::new(content_dir, build_dir, site_dir, template_dir);
+        plugin.after_compile(&ctx)?;
+        println!("multilingual_full: i18n pass complete — auditing output:");
+    }
+
     let mut found = 0usize;
     let mut missing = 0usize;
     for &lang in LOCALES {
@@ -85,9 +157,11 @@ fn main() -> Result<(), Box<dyn Error>> {
                 eprintln!("  MISSING: {}", p.display());
             }
         }
-        // Per-locale `index.md` lands at `<lang>/index/index.html`
-        // (staticdatagen treats every non-root .md as a subdir).
-        let idx = site_dir.join(lang).join("index").join("index.html");
+        // Per-locale `index.md` lands at `<lang>/index.html`. It used
+        // to gain a directory level (`<lang>/index/index.html`)
+        // because staticdatagen compares the whole processed name
+        // against "index"; the v0.0.50 content stager side-steps that.
+        let idx = site_dir.join(lang).join("index.html");
         if idx.exists() {
             found += 1;
         } else {
@@ -96,18 +170,70 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     }
 
-    let expected = LOCALES.len() * (POSTS_PER_LOCALE + 1);
+    // The translated-slug family: every page must exist, and every
+    // page must advertise the other four. A page that renders but
+    // pairs with nothing is the exact silent failure `translation_key`
+    // was added to fix, so "it built" is not the assertion worth
+    // making here — "it is reciprocally linked" is.
+    let mut unpaired = 0usize;
+    for &(lang, slug) in ABOUT_SLUGS {
+        let page = site_dir.join(lang).join(slug).join("index.html");
+        if !page.exists() {
+            missing += 1;
+            eprintln!("  MISSING: {}", page.display());
+            continue;
+        }
+        found += 1;
+
+        let html = std::fs::read_to_string(&page)?;
+        for &(other, other_slug) in ABOUT_SLUGS {
+            if other == lang {
+                continue;
+            }
+            // Match the alternate link itself, not the path anywhere
+            // on the page: the generated navbar links every page in
+            // the site, so a bare `contains("/fr/a-propos")` passes
+            // even when the hreflang block is empty.
+            let want = format!("/{other}/{other_slug}");
+            let paired = alternate_href(&html, other)
+                .is_some_and(|href| href.contains(&want));
+            if !paired {
+                unpaired += 1;
+                eprintln!(
+                    "  UNPAIRED: /{lang}/{slug}/ has no hreflang=\"{other}\" \
+                     alternate pointing at {want}"
+                );
+            }
+        }
+    }
+
+    let expected = LOCALES.len() * (POSTS_PER_LOCALE + 1) + ABOUT_SLUGS.len();
     println!(
-        "  found {found}/{expected} per-locale pages  ({missing} missing)"
+        "  found {found}/{expected} per-locale pages  \
+         ({missing} missing, {unpaired} unpaired)"
     );
 
     println!();
+
+    // Unpaired translations fail hard, everywhere, including CI.
+    // Page-count shortfalls stay soft because they track an upstream
+    // dependency we don't control; hreflang pairing is this crate's
+    // own behaviour, and a silent regression in it is what shipped
+    // broken in the first place.
+    if unpaired > 0 {
+        eprintln!(
+            "  ✗ {unpaired} missing alternate(s) — translated-slug pairing \
+             via `translation_key` has regressed."
+        );
+        std::process::exit(1);
+    }
+
     if missing > 0 {
         println!(
             "  ⚠ {missing} pages missing — staticdatagen recursive walk regressed?"
         );
         // Exit non-zero only when we have a regression worth flagging
-        // — staticdatagen 0.0.10 should now produce all 30 pages.
+        // — staticdatagen 0.0.11 should produce all 35 pages.
         if std::env::var("CI").is_err() {
             std::process::exit(1);
         }

--- a/src/plugins/i18n.rs
+++ b/src/plugins/i18n.rs
@@ -19,6 +19,56 @@
 //!
 //! The injection is **idempotent** — pages that already contain hreflang
 //! links are skipped.
+//!
+//! ## Pairing pages across locales
+//!
+//! Before anything can be injected, the plugin has to decide which
+//! pages in different locales are translations of one another. It
+//! builds a matrix of `key -> {locale -> path}` and treats every page
+//! sharing a key as one document.
+//!
+//! A page's key is its `translation_key` front-matter value when it
+//! declares one, and its locale-relative path otherwise:
+//!
+//! ```yaml
+//! ---
+//! title: "À propos"
+//! translation_key: "about"
+//! ---
+//! ```
+//!
+//! Path matching alone cannot pair `/about/` with `/fr/a-propos/` —
+//! the paths differ, so each is a singleton and **neither receives any
+//! hreflang at all**. Because that failure is silent, it is easy to
+//! ship. A shared `translation_key` pairs them regardless of slug.
+//!
+//! Pages without a key keep pairing by path, so a site with no
+//! `translation_key` anywhere produces exactly the matrix it produced
+//! before the field existed.
+//!
+//! The value is read from the front-matter sidecars written by
+//! [`crate::frontmatter::emit_sidecars`], because the plugin runs
+//! after compilation and can no longer see the source front matter.
+//!
+//! ## Where the default locale lives
+//!
+//! The default locale may occupy the site root, with only the other
+//! locales taking a URL segment (`/about/` alongside
+//! `/fr/a-propos/`) — the default in Hugo, Astro and Next.js. This is
+//! detected, not configured — the root locale is used when the default
+//! locale has no output directory of its own and HTML exists outside
+//! the other locale directories.
+//!
+//! ## Reciprocity
+//!
+//! Each alternate link is labelled with the resolved language of the
+//! document it points *at*, not with the bare locale directory name.
+//! Labelling by directory lets the two halves of a pair disagree — an
+//! English page calling its Hindi alternate `hi` while the Hindi page
+//! calls itself `hi-IN` — which fails Google's reciprocity requirement
+//! and the `hreflang` audit gate with it. An authored locale code is
+//! preserved byte-for-byte (`zh-tw` stays `zh-tw`); a resolved
+//! language replaces it only on a genuine front-matter override.
 
 use crate::error::{PathErrorExt, SsgError};
 use crate::plugin::{Plugin, PluginContext};

--- a/tests/release_versions.rs
+++ b/tests/release_versions.rs
@@ -1,0 +1,215 @@
+// Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Release version-coherence gate.
+//!
+//! Every publishable crate in the workspace must carry the same
+//! version as the root `ssg` crate, and every internal dependency
+//! pin must name that same version.
+//!
+//! ## What this catches
+//!
+//! Version drift between the root crate and the workspace members it
+//! depends on. `release.yml` publishes `ssg-core`, `ssg-rpc-macro`,
+//! `ssg-rpc`, `ssg-search` and `ssg-a11y` to crates.io before `ssg`
+//! itself, because crates.io verifies path dependencies against the
+//! registry. If a member's version was not bumped along with the
+//! root, the first `cargo publish` of the release aborts with
+//! `error: crate <name>@<version> already exists on crates.io index`
+//! and nothing downstream of it publishes.
+//!
+//! That is not hypothetical. Between v0.0.47 and v0.0.50 the members
+//! stayed pinned at `0.0.47` while the root advanced to `0.0.50`, so
+//! the v0.0.48 release failed at the very first publish, `ssg` was
+//! skipped, and crates.io fell two versions behind the README's own
+//! install instruction.
+//!
+//! The failure surfaced only after a tag had been pushed — the point
+//! at which it is most expensive, because a tag that produced no
+//! release has to be deleted and re-cut. This test moves the same
+//! signal to every `cargo test` run.
+//!
+//! ## Methodology
+//!
+//! Parse the root and member manifests directly. No TOML crate: the
+//! fields involved are single-line `key = "value"` entries, and
+//! `tests/docs_accuracy.rs` sets the precedent for keeping this kind
+//! of gate dependency-free.
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Members that `release.yml` publishes to crates.io, in the
+/// dependency order it uses. `ssg-wasm` is absent deliberately: it
+/// carries `publish = false` and is not a dependency of `ssg`.
+const PUBLISHED_MEMBERS: &[&str] = &[
+    "ssg-core",
+    "ssg-rpc-macro",
+    "ssg-rpc",
+    "ssg-search",
+    "ssg-a11y",
+];
+
+fn workspace() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn manifest_of(member: &str) -> PathBuf {
+    workspace().join("crates").join(member).join("Cargo.toml")
+}
+
+fn read(path: &Path) -> String {
+    fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+}
+
+/// Returns the `version = "…"` value from a manifest's `[package]`
+/// table, ignoring `version` keys that appear in dependency tables.
+fn package_version(path: &Path) -> String {
+    let toml = read(path);
+    let mut in_package = false;
+    for line in toml.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_package = trimmed == "[package]";
+            continue;
+        }
+        if in_package {
+            if let Some(rest) = trimmed.strip_prefix("version = \"") {
+                if let Some(v) = rest.split('"').next() {
+                    return v.to_string();
+                }
+            }
+        }
+    }
+    panic!("no [package] version in {}", path.display());
+}
+
+/// Returns every `version = "…"` pin attached to an internal
+/// `ssg-*` path dependency in `path`, as `(crate_name, pinned)`.
+///
+/// Matches the single-line inline-table form the workspace uses
+/// throughout, e.g.
+/// `ssg-core = { path = "crates/ssg-core", version = "0.0.50" }`.
+fn internal_pins(path: &Path) -> Vec<(String, String)> {
+    let toml = read(path);
+    let mut pins = Vec::new();
+    for line in toml.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((name, rest)) = trimmed.split_once(" = ") else {
+            continue;
+        };
+        if !name.starts_with("ssg-") || !rest.contains("path = ") {
+            continue;
+        }
+        if let Some(after) = rest.split("version = \"").nth(1) {
+            if let Some(v) = after.split('"').next() {
+                pins.push((name.to_string(), v.to_string()));
+            }
+        }
+    }
+    pins
+}
+
+#[test]
+fn published_members_match_the_root_version() {
+    let root = package_version(&workspace().join("Cargo.toml"));
+    let mut drift = Vec::new();
+
+    for member in PUBLISHED_MEMBERS {
+        let got = package_version(&manifest_of(member));
+        if got != root {
+            drift.push(format!(
+                "  crates/{member}/Cargo.toml: {got}  (want {root})"
+            ));
+        }
+    }
+
+    assert!(
+        drift.is_empty(),
+        "workspace members have drifted from the root version {root}.\n\
+         `cargo publish` will abort with \"already exists on crates.io \
+         index\" on the first of these and the release will publish \
+         nothing:\n{}\n\nBump each to {root}, refresh Cargo.lock, and \
+         re-run.",
+        drift.join("\n")
+    );
+}
+
+#[test]
+fn ssg_wasm_matches_the_root_version_even_though_it_is_unpublished() {
+    // `publish = false` keeps it off crates.io, but leaving it behind
+    // makes `cargo metadata` output and release notes inconsistent,
+    // and it is the member most likely to be forgotten precisely
+    // because the publish step never touches it.
+    let root = package_version(&workspace().join("Cargo.toml"));
+    let got = package_version(&manifest_of("ssg-wasm"));
+    assert_eq!(
+        got, root,
+        "crates/ssg-wasm/Cargo.toml is at {got}, root is at {root}"
+    );
+}
+
+#[test]
+fn internal_dependency_pins_match_the_root_version() {
+    let root = package_version(&workspace().join("Cargo.toml"));
+    let mut stale = Vec::new();
+
+    let mut manifests = vec![workspace().join("Cargo.toml")];
+    manifests.extend(PUBLISHED_MEMBERS.iter().map(|m| manifest_of(m)));
+    manifests.push(manifest_of("ssg-wasm"));
+
+    for manifest in &manifests {
+        for (dep, pinned) in internal_pins(manifest) {
+            if pinned != root {
+                stale.push(format!(
+                    "  {}: {dep} pinned at {pinned}  (want {root})",
+                    manifest
+                        .strip_prefix(workspace())
+                        .unwrap_or(manifest)
+                        .display()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        stale.is_empty(),
+        "internal dependency pins have drifted from the root version \
+         {root}.\ncrates.io resolves these against the registry, so a \
+         stale pin either publishes against an old sub-crate or fails \
+         outright:\n{}",
+        stale.join("\n")
+    );
+}
+
+#[test]
+fn published_members_list_matches_the_release_workflow() {
+    // The list above only protects what `release.yml` actually
+    // publishes. If a member is added to the workflow loop without
+    // being added here, it silently loses its version gate.
+    let workflow = read(&workspace().join(".github/workflows/release.yml"));
+    let loop_line = workflow
+        .lines()
+        .find(|l| l.trim_start().starts_with("for c in ssg-"))
+        .expect("release.yml no longer has the `for c in ssg-…` publish loop");
+
+    let in_workflow: Vec<&str> = loop_line
+        .trim()
+        .trim_start_matches("for c in ")
+        .trim_end_matches("; do")
+        .split_whitespace()
+        .collect();
+
+    assert_eq!(
+        in_workflow, PUBLISHED_MEMBERS,
+        "release.yml publishes a different set of crates than this \
+         test guards.\nrelease.yml: {in_workflow:?}\nthis test:  \
+         {PUBLISHED_MEMBERS:?}"
+    );
+}


### PR DESCRIPTION
Prepares v0.0.50 to actually ship. Two tracks: the release pipeline, and the documentation debt from #668.

## Why the pipeline could not publish

Nothing has published cleanly since v0.0.46. crates.io is on `ssg` 0.0.48 while this repo says 0.0.50.

| Release | Outcome | Cause |
|---|---|---|
| v0.0.47 | failure | `ssg-a11y` not on crates.io; root publish could not resolve it |
| v0.0.48 | failure | sub-crate version drift, then the idempotency guard misfired |
| v0.0.49 | cancelled | manually cancelled 54s in; the tag started two heavyweight runs |

Three faults, each masking the next:

1. **Version drift.** Members sat at `0.0.47` while the root moved to `0.0.50`, so `cargo publish -p ssg-core` hit `already exists on crates.io index` on the first crate of every release.
2. **The guard that should have absorbed it.** It probed `https://crates.io/api/v1/crates/<crate>/<version>` over HTTP. That request failed from the runner (it returns 200 from a developer machine), so a crate that *was* published was reported missing, the step exited 1, and `Publish ssg to crates.io` was skipped.
3. **GHCR.** `cache-to: type=gha` failed with `ERROR: not_found` after a 126.9s export — a green build that shipped no image.

Plus: `scheduled.yml` fired on `v*` tags, described as "release-gating coverage", but `release.yml` never waited on it. A tag started two heavyweight runs and gated nothing. Both were cancelled together at v0.0.49.

## Fixed

- All six workspace members and the four root pins track the root version.
- `tests/release_versions.rs` fails on drift **before** a tag is cut. Verified failing against the exact v0.0.48 drift.
- The publish guard reads cargo's stderr instead of the network. The root crate gained the same idempotency and still publishes with verification.
- GHCR cache moved off the Actions Cache service, with `ignore-error=true`.
- `scheduled.yml` no longer triggers on tags; `release.yml` has a concurrency group with `cancel-in-progress: false`.

## Documentation

`translation_key` shipped in exactly two files: the plugin source and the changelog. `docs_accuracy` did not catch it — it verifies numeric claims, not whether a feature is described.

- `docs/guide/i18n.md` documented the identical-path model this release replaced. Rewritten against actual behaviour.
- `docs/guide/content.md` lists `translation_key` in the front-matter table.
- `src/plugins/i18n.rs` module docs cover pairing and reciprocity — the existing rustdoc sat on private items and never reached docs.rs.
- README describes the feature; its test-suite figures are now measured.

## Example

`examples/multilingual_full` audited the **pre-0.0.50** layout (`<lang>/index/index.html`) and reported all five locale home pages missing on every run. It now checks the correct path, demonstrates translated slugs across five locales, and asserts **reciprocal** pairing — verified failing when a `translation_key` is removed.

## Verification

```
cargo test --lib          3566 passed, 0 failed
cargo clippy --all-features --all-targets   clean
cargo fmt --all --check   clean
docs_accuracy             12 passed
doc_links                  4 passed
release_versions           4 passed
cargo publish --dry-run   clean for all five sub-crates
```

Every new gate was observed failing before its fix.

## One pre-existing defect found, not fixed here

Building `multilingual_full` makes `tests/element_presence.rs` fail. On **unmodified `main`** that is 125 invariant violations across 31 pages — missing `og:title`/`og:description`/`og:type`, missing `twitter:card`, missing charset. This branch adds 5 pages to that set (145 across 36).

The cause is that the example calls `compile_site`, which registers no plugins, so the SEO plugins never run. CI never sees it because `example_outputs.rs` doesn't run `multilingual_full`, so its `public/` is never populated — which is also why #495's "passing across every built example page" held.

Moving the example onto `build_pipeline` is the real fix. I tried it: it needs front matter this example's content doesn't have (the manifest, CNAME and humans templates render empty and `ManifestFixPlugin` then fails on the 0-byte file). That is its own piece of work, so the example carries a comment pointing at it rather than a half-migration.

## After merge

Tag from `main`:

```
./.git/release-v0.0.50.sh tag
```