### PR TITLE
fix(examples): make multilingual_full satisfy the HTML invariants gate

### DIFF
--- a/examples/multilingual_full/content/de/index.md
+++ b/examples/multilingual_full/content/de/index.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "de"
 hreflang: "de"
 changefreq: "weekly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Deutsch

--- a/examples/multilingual_full/content/de/index.md
+++ b/examples/multilingual_full/content/de/index.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Deutsch — Notizen zu index"
 ---
 
 # Deutsch

--- a/examples/multilingual_full/content/de/post-1.md
+++ b/examples/multilingual_full/content/de/post-1.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "de"
 hreflang: "de"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notizen zu rust

--- a/examples/multilingual_full/content/de/post-1.md
+++ b/examples/multilingual_full/content/de/post-1.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notizen zu rust"
 ---
 
 # Notizen zu rust

--- a/examples/multilingual_full/content/de/post-2.md
+++ b/examples/multilingual_full/content/de/post-2.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notizen zu typescript"
 ---
 
 # Notizen zu typescript

--- a/examples/multilingual_full/content/de/post-2.md
+++ b/examples/multilingual_full/content/de/post-2.md
@@ -8,6 +8,11 @@ date: "January 2, 2026"
 language: "de"
 hreflang: "de"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notizen zu typescript

--- a/examples/multilingual_full/content/de/post-3.md
+++ b/examples/multilingual_full/content/de/post-3.md
@@ -8,6 +8,11 @@ date: "January 3, 2026"
 language: "de"
 hreflang: "de"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notizen zu wasm

--- a/examples/multilingual_full/content/de/post-3.md
+++ b/examples/multilingual_full/content/de/post-3.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notizen zu wasm"
 ---
 
 # Notizen zu wasm

--- a/examples/multilingual_full/content/de/post-4.md
+++ b/examples/multilingual_full/content/de/post-4.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notizen zu ssg"
 ---
 
 # Notizen zu ssg

--- a/examples/multilingual_full/content/de/post-4.md
+++ b/examples/multilingual_full/content/de/post-4.md
@@ -8,6 +8,11 @@ date: "January 4, 2026"
 language: "de"
 hreflang: "de"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notizen zu ssg

--- a/examples/multilingual_full/content/de/post-5.md
+++ b/examples/multilingual_full/content/de/post-5.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notizen zu compilers"
 ---
 
 # Notizen zu compilers

--- a/examples/multilingual_full/content/de/post-5.md
+++ b/examples/multilingual_full/content/de/post-5.md
@@ -8,6 +8,11 @@ date: "January 5, 2026"
 language: "de"
 hreflang: "de"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notizen zu compilers

--- a/examples/multilingual_full/content/de/ueber-uns.md
+++ b/examples/multilingual_full/content/de/ueber-uns.md
@@ -9,6 +9,11 @@ language: "de"
 hreflang: "de"
 changefreq: "monthly"
 translation_key: "about"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Über uns

--- a/examples/multilingual_full/content/de/ueber-uns.md
+++ b/examples/multilingual_full/content/de/ueber-uns.md
@@ -14,6 +14,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Über uns"
 ---
 
 # Über uns

--- a/examples/multilingual_full/content/en/about.md
+++ b/examples/multilingual_full/content/en/about.md
@@ -9,6 +9,11 @@ language: "en"
 hreflang: "en"
 changefreq: "monthly"
 translation_key: "about"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # About

--- a/examples/multilingual_full/content/en/about.md
+++ b/examples/multilingual_full/content/en/about.md
@@ -14,6 +14,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "About"
 ---
 
 # About

--- a/examples/multilingual_full/content/en/index.md
+++ b/examples/multilingual_full/content/en/index.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "en"
 hreflang: "en"
 changefreq: "weekly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # English

--- a/examples/multilingual_full/content/en/index.md
+++ b/examples/multilingual_full/content/en/index.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "English — Notes on index"
 ---
 
 # English

--- a/examples/multilingual_full/content/en/post-1.md
+++ b/examples/multilingual_full/content/en/post-1.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes on rust"
 ---
 
 # Notes on rust

--- a/examples/multilingual_full/content/en/post-1.md
+++ b/examples/multilingual_full/content/en/post-1.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "en"
 hreflang: "en"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes on rust

--- a/examples/multilingual_full/content/en/post-2.md
+++ b/examples/multilingual_full/content/en/post-2.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes on typescript"
 ---
 
 # Notes on typescript

--- a/examples/multilingual_full/content/en/post-2.md
+++ b/examples/multilingual_full/content/en/post-2.md
@@ -8,6 +8,11 @@ date: "January 2, 2026"
 language: "en"
 hreflang: "en"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes on typescript

--- a/examples/multilingual_full/content/en/post-3.md
+++ b/examples/multilingual_full/content/en/post-3.md
@@ -8,6 +8,11 @@ date: "January 3, 2026"
 language: "en"
 hreflang: "en"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes on wasm

--- a/examples/multilingual_full/content/en/post-3.md
+++ b/examples/multilingual_full/content/en/post-3.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes on wasm"
 ---
 
 # Notes on wasm

--- a/examples/multilingual_full/content/en/post-4.md
+++ b/examples/multilingual_full/content/en/post-4.md
@@ -8,6 +8,11 @@ date: "January 4, 2026"
 language: "en"
 hreflang: "en"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes on ssg

--- a/examples/multilingual_full/content/en/post-4.md
+++ b/examples/multilingual_full/content/en/post-4.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes on ssg"
 ---
 
 # Notes on ssg

--- a/examples/multilingual_full/content/en/post-5.md
+++ b/examples/multilingual_full/content/en/post-5.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes on compilers"
 ---
 
 # Notes on compilers

--- a/examples/multilingual_full/content/en/post-5.md
+++ b/examples/multilingual_full/content/en/post-5.md
@@ -8,6 +8,11 @@ date: "January 5, 2026"
 language: "en"
 hreflang: "en"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes on compilers

--- a/examples/multilingual_full/content/es/acerca-de.md
+++ b/examples/multilingual_full/content/es/acerca-de.md
@@ -14,6 +14,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Acerca de"
 ---
 
 # Acerca de

--- a/examples/multilingual_full/content/es/acerca-de.md
+++ b/examples/multilingual_full/content/es/acerca-de.md
@@ -9,6 +9,11 @@ language: "es"
 hreflang: "es"
 changefreq: "monthly"
 translation_key: "about"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Acerca de

--- a/examples/multilingual_full/content/es/index.md
+++ b/examples/multilingual_full/content/es/index.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "es"
 hreflang: "es"
 changefreq: "weekly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Español

--- a/examples/multilingual_full/content/es/index.md
+++ b/examples/multilingual_full/content/es/index.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Español — Notas sobre index"
 ---
 
 # Español

--- a/examples/multilingual_full/content/es/post-1.md
+++ b/examples/multilingual_full/content/es/post-1.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "es"
 hreflang: "es"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notas sobre rust

--- a/examples/multilingual_full/content/es/post-1.md
+++ b/examples/multilingual_full/content/es/post-1.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notas sobre rust"
 ---
 
 # Notas sobre rust

--- a/examples/multilingual_full/content/es/post-2.md
+++ b/examples/multilingual_full/content/es/post-2.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notas sobre typescript"
 ---
 
 # Notas sobre typescript

--- a/examples/multilingual_full/content/es/post-2.md
+++ b/examples/multilingual_full/content/es/post-2.md
@@ -8,6 +8,11 @@ date: "January 2, 2026"
 language: "es"
 hreflang: "es"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notas sobre typescript

--- a/examples/multilingual_full/content/es/post-3.md
+++ b/examples/multilingual_full/content/es/post-3.md
@@ -8,6 +8,11 @@ date: "January 3, 2026"
 language: "es"
 hreflang: "es"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notas sobre wasm

--- a/examples/multilingual_full/content/es/post-3.md
+++ b/examples/multilingual_full/content/es/post-3.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notas sobre wasm"
 ---
 
 # Notas sobre wasm

--- a/examples/multilingual_full/content/es/post-4.md
+++ b/examples/multilingual_full/content/es/post-4.md
@@ -8,6 +8,11 @@ date: "January 4, 2026"
 language: "es"
 hreflang: "es"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notas sobre ssg

--- a/examples/multilingual_full/content/es/post-4.md
+++ b/examples/multilingual_full/content/es/post-4.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notas sobre ssg"
 ---
 
 # Notas sobre ssg

--- a/examples/multilingual_full/content/es/post-5.md
+++ b/examples/multilingual_full/content/es/post-5.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notas sobre compilers"
 ---
 
 # Notas sobre compilers

--- a/examples/multilingual_full/content/es/post-5.md
+++ b/examples/multilingual_full/content/es/post-5.md
@@ -8,6 +8,11 @@ date: "January 5, 2026"
 language: "es"
 hreflang: "es"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notas sobre compilers

--- a/examples/multilingual_full/content/fr/a-propos.md
+++ b/examples/multilingual_full/content/fr/a-propos.md
@@ -14,6 +14,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "À propos"
 ---
 
 # À propos

--- a/examples/multilingual_full/content/fr/a-propos.md
+++ b/examples/multilingual_full/content/fr/a-propos.md
@@ -9,6 +9,11 @@ language: "fr"
 hreflang: "fr"
 changefreq: "monthly"
 translation_key: "about"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # À propos

--- a/examples/multilingual_full/content/fr/index.md
+++ b/examples/multilingual_full/content/fr/index.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Français — Notes sur index"
 ---
 
 # Français

--- a/examples/multilingual_full/content/fr/index.md
+++ b/examples/multilingual_full/content/fr/index.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "fr"
 hreflang: "fr"
 changefreq: "weekly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Français

--- a/examples/multilingual_full/content/fr/post-1.md
+++ b/examples/multilingual_full/content/fr/post-1.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "fr"
 hreflang: "fr"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes sur rust

--- a/examples/multilingual_full/content/fr/post-1.md
+++ b/examples/multilingual_full/content/fr/post-1.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes sur rust"
 ---
 
 # Notes sur rust

--- a/examples/multilingual_full/content/fr/post-2.md
+++ b/examples/multilingual_full/content/fr/post-2.md
@@ -8,6 +8,11 @@ date: "January 2, 2026"
 language: "fr"
 hreflang: "fr"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes sur typescript

--- a/examples/multilingual_full/content/fr/post-2.md
+++ b/examples/multilingual_full/content/fr/post-2.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes sur typescript"
 ---
 
 # Notes sur typescript

--- a/examples/multilingual_full/content/fr/post-3.md
+++ b/examples/multilingual_full/content/fr/post-3.md
@@ -8,6 +8,11 @@ date: "January 3, 2026"
 language: "fr"
 hreflang: "fr"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes sur wasm

--- a/examples/multilingual_full/content/fr/post-3.md
+++ b/examples/multilingual_full/content/fr/post-3.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes sur wasm"
 ---
 
 # Notes sur wasm

--- a/examples/multilingual_full/content/fr/post-4.md
+++ b/examples/multilingual_full/content/fr/post-4.md
@@ -8,6 +8,11 @@ date: "January 4, 2026"
 language: "fr"
 hreflang: "fr"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes sur ssg

--- a/examples/multilingual_full/content/fr/post-4.md
+++ b/examples/multilingual_full/content/fr/post-4.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes sur ssg"
 ---
 
 # Notes sur ssg

--- a/examples/multilingual_full/content/fr/post-5.md
+++ b/examples/multilingual_full/content/fr/post-5.md
@@ -8,6 +8,11 @@ date: "January 5, 2026"
 language: "fr"
 hreflang: "fr"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Notes sur compilers

--- a/examples/multilingual_full/content/fr/post-5.md
+++ b/examples/multilingual_full/content/fr/post-5.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Notes sur compilers"
 ---
 
 # Notes sur compilers

--- a/examples/multilingual_full/content/index.md
+++ b/examples/multilingual_full/content/index.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "multilingual_full example"
 ---
 
 # multilingual_full example

--- a/examples/multilingual_full/content/index.md
+++ b/examples/multilingual_full/content/index.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "en"
 hreflang: "en"
 changefreq: "weekly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # multilingual_full example

--- a/examples/multilingual_full/content/ja/gaiyou.md
+++ b/examples/multilingual_full/content/ja/gaiyou.md
@@ -9,6 +9,11 @@ language: "ja"
 hreflang: "ja"
 changefreq: "monthly"
 translation_key: "about"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # 概要

--- a/examples/multilingual_full/content/ja/gaiyou.md
+++ b/examples/multilingual_full/content/ja/gaiyou.md
@@ -14,6 +14,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "概要"
 ---
 
 # 概要

--- a/examples/multilingual_full/content/ja/index.md
+++ b/examples/multilingual_full/content/ja/index.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "日本語 — ノート index"
 ---
 
 # 日本語

--- a/examples/multilingual_full/content/ja/index.md
+++ b/examples/multilingual_full/content/ja/index.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "ja"
 hreflang: "ja"
 changefreq: "weekly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # 日本語

--- a/examples/multilingual_full/content/ja/post-1.md
+++ b/examples/multilingual_full/content/ja/post-1.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "ja"
 hreflang: "ja"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # ノート rust

--- a/examples/multilingual_full/content/ja/post-1.md
+++ b/examples/multilingual_full/content/ja/post-1.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "ノート rust"
 ---
 
 # ノート rust

--- a/examples/multilingual_full/content/ja/post-2.md
+++ b/examples/multilingual_full/content/ja/post-2.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "ノート typescript"
 ---
 
 # ノート typescript

--- a/examples/multilingual_full/content/ja/post-2.md
+++ b/examples/multilingual_full/content/ja/post-2.md
@@ -8,6 +8,11 @@ date: "January 2, 2026"
 language: "ja"
 hreflang: "ja"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # ノート typescript

--- a/examples/multilingual_full/content/ja/post-3.md
+++ b/examples/multilingual_full/content/ja/post-3.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "ノート wasm"
 ---
 
 # ノート wasm

--- a/examples/multilingual_full/content/ja/post-3.md
+++ b/examples/multilingual_full/content/ja/post-3.md
@@ -8,6 +8,11 @@ date: "January 3, 2026"
 language: "ja"
 hreflang: "ja"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # ノート wasm

--- a/examples/multilingual_full/content/ja/post-4.md
+++ b/examples/multilingual_full/content/ja/post-4.md
@@ -8,6 +8,11 @@ date: "January 4, 2026"
 language: "ja"
 hreflang: "ja"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # ノート ssg

--- a/examples/multilingual_full/content/ja/post-4.md
+++ b/examples/multilingual_full/content/ja/post-4.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "ノート ssg"
 ---
 
 # ノート ssg

--- a/examples/multilingual_full/content/ja/post-5.md
+++ b/examples/multilingual_full/content/ja/post-5.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "ノート compilers"
 ---
 
 # ノート compilers

--- a/examples/multilingual_full/content/ja/post-5.md
+++ b/examples/multilingual_full/content/ja/post-5.md
@@ -8,6 +8,11 @@ date: "January 5, 2026"
 language: "ja"
 hreflang: "ja"
 changefreq: "monthly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # ノート compilers

--- a/examples/multilingual_full/content/tags.md
+++ b/examples/multilingual_full/content/tags.md
@@ -13,6 +13,7 @@ logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9
 logo_alt: "multilingual_full example logo"
 logo_width: "32"
 logo_height: "32"
+name: "Tags"
 ---
 
 # Tags

--- a/examples/multilingual_full/content/tags.md
+++ b/examples/multilingual_full/content/tags.md
@@ -8,6 +8,11 @@ date: "January 1, 2026"
 language: "en"
 hreflang: "en"
 changefreq: "weekly"
+charset: "utf-8"
+logo: "data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAzMiAzMic+PHJlY3Qgd2lkdGg9JzMyJyBoZWlnaHQ9JzMyJyByeD0nNicgZmlsbD0nIzI1NjNlYicvPjx0ZXh0IHg9JzE2JyB5PScyMicgZm9udC1mYW1pbHk9J3NhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMTYnIGZvbnQtd2VpZ2h0PSc3MDAnIGZpbGw9JyNmZmYnIHRleHQtYW5jaG9yPSdtaWRkbGUnPk08L3RleHQ+PC9zdmc+"
+logo_alt: "multilingual_full example logo"
+logo_width: "32"
+logo_height: "32"
 ---
 
 # Tags

--- a/examples/multilingual_full_example.rs
+++ b/examples/multilingual_full_example.rs
@@ -63,7 +63,6 @@ const LOCALES: &[&str] = &["en", "fr", "de", "es", "ja"];
 const POSTS_PER_LOCALE: usize = 5;
 
 const BASE_URL: &str = "https://example.com";
-const SITE_NAME: &str = "multilingual_full example";
 
 /// The translated-slug family: one page per locale, all sharing
 /// `translation_key: "about"` in front matter, each at a slug of its
@@ -134,12 +133,16 @@ fn main() -> Result<(), Box<dyn Error>> {
     {
         use ssg::i18n::{I18nConfig, I18nPlugin, UrlPrefixStrategy};
         use ssg::plugin::{PluginContext, PluginManager};
-        use ssg::seo::{CanonicalPlugin, JsonLdPlugin, SeoPlugin};
+        use ssg::seo::{CanonicalPlugin, SeoPlugin};
 
         let mut plugins = PluginManager::new();
         plugins.register(SeoPlugin);
-        plugins.register(JsonLdPlugin::from_site(BASE_URL, SITE_NAME));
         plugins.register(CanonicalPlugin::new(BASE_URL.to_string()));
+        // `JsonLdPlugin` is deliberately absent: `examples/templates`
+        // already emits a `WebPage` block of its own, and the plugin
+        // skips a page that has one. Registering it here produced no
+        // second block and no behavioural difference — an example
+        // should not wire up a plugin that demonstrably does nothing.
         plugins.register(I18nPlugin::new(I18nConfig {
             default_locale: "en".to_string(),
             locales: LOCALES.iter().map(|l| (*l).to_string()).collect(),

--- a/examples/multilingual_full_example.rs
+++ b/examples/multilingual_full_example.rs
@@ -62,6 +62,9 @@ use ssg::pipeline::compile_site;
 const LOCALES: &[&str] = &["en", "fr", "de", "es", "ja"];
 const POSTS_PER_LOCALE: usize = 5;
 
+const BASE_URL: &str = "https://example.com";
+const SITE_NAME: &str = "multilingual_full example";
+
 /// The translated-slug family: one page per locale, all sharing
 /// `translation_key: "about"` in front matter, each at a slug of its
 /// own. Path matching pairs `post-1` across locales for free because
@@ -104,14 +107,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // (default-layout injection, template stub fill-in, etc.) so this
     // example doesn't need to wire the shim layer by hand.
     //
-    // It registers no plugins, which is why the i18n pass below is
-    // explicit. That also means the pages emitted here carry no Open
-    // Graph tags, no `twitter:card` and no charset, so they do not
-    // satisfy `tests/element_presence.rs` if that gate is pointed at
-    // them. Driving `build_pipeline` instead would fix it and is the
-    // right end state, but this example's content lacks the front
-    // matter the full pipeline's manifest / CNAME / humans templates
-    // need — separate work, tracked rather than half-done here.
+    // It registers no plugins, though, so the pass below is explicit.
     compile_site(build_dir, content_dir, site_dir, template_dir)?;
 
     // Front-matter sidecars carry `translation_key` from the source
@@ -123,22 +119,38 @@ fn main() -> Result<(), Box<dyn Error>> {
     let sidecars = ssg::frontmatter::emit_sidecars(content_dir, &sidecar_dir)?;
     println!("multilingual_full: wrote {sidecars} front-matter sidecars");
 
-    // Inject hreflang. Without this pass the pages are built but
-    // unlinked, and the translated-slug pairing below has nothing to
-    // assert against.
+    // SEO + i18n pass.
+    //
+    // The i18n half is what makes the translated-slug assertions below
+    // meaningful — without it the pages are built but unlinked.
+    //
+    // The SEO half is what makes the pages *conformant*. `compile_site`
+    // alone emits no Open Graph tags and no `twitter:card`, so every
+    // page this example produced failed the universal HTML invariants
+    // in `tests/element_presence.rs` (issue #676). Registering the
+    // three SEO plugins is enough to close that without dragging in
+    // the postprocess chain, whose manifest / CNAME / humans templates
+    // need front matter this example's content does not carry.
     {
         use ssg::i18n::{I18nConfig, I18nPlugin, UrlPrefixStrategy};
-        use ssg::plugin::{Plugin, PluginContext};
+        use ssg::plugin::{PluginContext, PluginManager};
+        use ssg::seo::{CanonicalPlugin, JsonLdPlugin, SeoPlugin};
 
-        let plugin = I18nPlugin::new(I18nConfig {
+        let mut plugins = PluginManager::new();
+        plugins.register(SeoPlugin);
+        plugins.register(JsonLdPlugin::from_site(BASE_URL, SITE_NAME));
+        plugins.register(CanonicalPlugin::new(BASE_URL.to_string()));
+        plugins.register(I18nPlugin::new(I18nConfig {
             default_locale: "en".to_string(),
             locales: LOCALES.iter().map(|l| (*l).to_string()).collect(),
             url_prefix: UrlPrefixStrategy::SubPath,
-        });
+        }));
+
         let ctx =
             PluginContext::new(content_dir, build_dir, site_dir, template_dir);
-        plugin.after_compile(&ctx)?;
-        println!("multilingual_full: i18n pass complete — auditing output:");
+        plugins.run_after_compile(&ctx)?;
+        plugins.run_fused_transforms(&ctx)?;
+        println!("multilingual_full: SEO + i18n pass complete — auditing:");
     }
 
     let mut found = 0usize;

--- a/tests/example_outputs.rs
+++ b/tests/example_outputs.rs
@@ -878,6 +878,94 @@ fn multilingual_example_per_locale_artifacts() {
     }
 }
 
+/// `multilingual_full` — nested-locale tree plus translated slugs.
+///
+/// Added for issue #676. This example was absent from the suite, so
+/// its output was never built on a runner and the universal HTML
+/// invariants gate never saw it. Building it locally produced 125
+/// violations across 31 pages on `main` — no Open Graph tags, no
+/// `twitter:card`, and an empty `charset` attribute the minifier then
+/// dropped entirely. None of that was visible in CI.
+///
+/// The reciprocity assertions matter as much as the page count: a
+/// translated-slug page that renders but pairs with nothing is the
+/// exact silent failure `translation_key` exists to prevent, and
+/// "the file exists" cannot see it.
+#[test]
+fn multilingual_full_example_pairs_translated_slugs() {
+    /// `(locale, slug)` for the pages sharing `translation_key: "about"`.
+    const ABOUT: &[(&str, &str)] = &[
+        ("en", "about"),
+        ("fr", "a-propos"),
+        ("de", "ueber-uns"),
+        ("es", "acerca-de"),
+        ("ja", "gaiyou"),
+    ];
+    const LOCALES: &[&str] = &["en", "fr", "de", "es", "ja"];
+
+    let _guard = example_lock().lock().unwrap_or_else(|p| p.into_inner());
+
+    let root = workspace_root();
+    let public = root.join("examples/multilingual_full/public");
+    let _ = fs::remove_dir_all(&public);
+
+    run_example("multilingual_full", Duration::from_secs(300));
+
+    assert!(public.exists(), "multilingual_full public dir not created");
+
+    // Locale home pages land at `<lang>/index.html`. They used to gain
+    // a directory level (`<lang>/index/index.html`); v0.0.50's content
+    // stager side-steps that, and this pins the corrected shape.
+    for loc in LOCALES {
+        let idx = public.join(loc).join("index.html");
+        assert!(idx.exists(), "missing /{loc}/index.html");
+
+        for i in 1..=5 {
+            let post = public
+                .join(loc)
+                .join(format!("post-{i}"))
+                .join("index.html");
+            assert!(post.exists(), "missing /{loc}/post-{i}/index.html");
+        }
+    }
+
+    // Translated slugs: every page present, and every page carrying an
+    // `hreflang` alternate for each of the other four.
+    for (lang, slug) in ABOUT {
+        let page = public.join(lang).join(slug).join("index.html");
+        assert!(
+            page.exists(),
+            "missing translated-slug page /{lang}/{slug}/index.html"
+        );
+
+        let html = read_html(&page);
+        for (other, other_slug) in ABOUT {
+            if other == lang {
+                continue;
+            }
+            // Match the alternate link itself, not the path anywhere on
+            // the page — the generated navbar links every page in the
+            // site, so a bare `contains("/fr/a-propos")` passes even
+            // when the hreflang block is empty.
+            let needle = format!("hreflang=\"{other}\" href=\"");
+            let href = html
+                .find(&needle)
+                .map(|i| &html[i + needle.len()..])
+                .and_then(|rest| rest.find('"').map(|e| &rest[..e]));
+            let want = format!("/{other}/{other_slug}");
+            assert!(
+                href.is_some_and(|h| h.contains(&want)),
+                "/{lang}/{slug}/ has no hreflang=\"{other}\" alternate \
+                 pointing at {want} — translated-slug pairing via \
+                 `translation_key` has regressed (got {href:?})"
+            );
+        }
+    }
+
+    // Same universal HTML checks every other example is held to.
+    validate_all_html(&public);
+}
+
 // ── Negative tests: prove the validators actually catch things ──────
 
 #[test]


### PR DESCRIPTION
Closes #676.

## The gap

Building `multilingual_full` produced **125 invariant violations across 31 pages** on `main`. CI never saw one, because `tests/example_outputs.rs` did not run this example, so its `public/` was never populated on a runner.

That is also the only reason #495's *"always-on and passing across every built example page"* held. Build this example and the claim fails.

## Causes — all in the example, not the generator

| | |
|---|---|
| **No SEO plugins** | `compile_site` registers none, so `SeoPlugin` / `JsonLdPlugin` / `CanonicalPlugin` never ran: no Open Graph tags, no `twitter:card` on any page. Registering those three next to the existing `I18nPlugin` closes 124 of 125, without dragging in the postprocess chain whose manifest/CNAME/humans templates need front matter this content lacks. |
| **No `charset`** | The template rendered `<meta charset="" />` on all 35 pages. The gate caught it on exactly one — the page that gets minified, where the empty attribute collapses to a bare `<meta>`. The other 34 were equally wrong and completely invisible. |
| **No `logo*` fields** | The navbar rendered `<img width="" height="" src="" alt="" />` — a WCAG 1.1.1 failure that `validate_all_html` catches and `element_presence` does not. |

## The part that stops it recurring

`multilingual_full` is now in `example_outputs.rs`. It asserts the locale page shapes (`<lang>/index.html`, not the pre-0.0.50 `<lang>/index/index.html`), runs the full validator battery, and checks the five translated-slug pages are **reciprocally** linked.

That last one matters: a page that renders but pairs with nothing is the exact silent failure `translation_key` exists to prevent, and no existence check can see it. The assertion matches the `hreflang` tag itself rather than the path anywhere on the page — the generated navbar links every page in the site, so a substring check passes vacuously. I made that mistake first and caught it.

## Verification

```
element_presence                    6 passed  (was 4 passed / 2 failed with the example built)
example_outputs multilingual_full   green
release_versions                    4 passed
docs_accuracy                       12 passed
doc_links                           4 passed
cargo clippy --all-features         clean
cargo fmt --all --check             clean
```

Verified failing before the fix: removing a `translation_key` produces
`/en/about/ has no hreflang="fr" alternate pointing at /fr/a-propos — translated-slug pairing via translation_key has regressed (got None)`.