### PR TITLE
fix(release): make the GPG signatures actually reach the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,7 +472,24 @@ jobs:
   # ── GitHub Release + crates.io publish ──────────────────────────
   publish:
     name: github release · crates.io
-    needs: [build]
+    # `gpg-sign` is here so its detached signatures exist BEFORE this job
+    # downloads artifacts. Without it the two ran concurrently: this job
+    # takes every artifact present at that instant, so the `.asc` files
+    # usually lost the race and never reached the release — while
+    # SECURITY.md and the generated release notes both told users to run
+    # `gpg --verify`. Configuring the GPG secrets alone would not have
+    # fixed that.
+    #
+    # `gpg-sign` is itself conditional on the GPG secret existing, and a
+    # skipped dependency skips its dependents by default — which would
+    # mean no secret, no release at all. Hence the explicit result check
+    # below: proceed when it succeeded OR was skipped, fail only when it
+    # actually failed.
+    needs: [build, gpg-sign]
+    if: >-
+      !cancelled() &&
+      needs.build.result == 'success' &&
+      (needs.gpg-sign.result == 'success' || needs.gpg-sign.result == 'skipped')
     # GHCR is best-effort (multi-arch builds can be flaky); don't gate
     # the GitHub Release or crates.io publish on it.
     runs-on: ubuntu-latest


### PR DESCRIPTION
Prerequisite for enabling artifact signing. **Configuring the GPG secrets alone would not have produced signed releases** — this is the reason why.

## The defect

`publish` (github release · crates.io) had `needs: [build]` only, so it ran **concurrently** with `gpg-sign`. It downloads artifacts with `merge-multiple: true` and no name filter — i.e. whatever exists at that instant — then uploads `artifacts/*` to the release.

The `.asc` files therefore lost the race. They were produced, uploaded as a 7-day workflow artifact, and quietly dropped before the release was assembled.

Meanwhile both `SECURITY.md` and the generated release notes tell users to run:

```sh
gpg --verify ssg-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz.asc \
             ssg-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz
```

...against a file that was never attached.

## Why the obvious fix breaks releases

`gpg-sign` is conditional on `has_gpg`, and **a skipped dependency skips its dependents by default**. Plain `needs: [build, gpg-sign]` would mean *no GPG secret → no release at all* — turning an optional feature into a hard requirement.

So the gate is explicit: proceed when `gpg-sign` **succeeded or was skipped**, fail only when it genuinely failed.

```yaml
needs: [build, gpg-sign]
if: >-
  !cancelled() &&
  needs.build.result == 'success' &&
  (needs.gpg-sign.result == 'success' || needs.gpg-sign.result == 'skipped')
```

## Verification

`actionlint` type-checks the `needs.gpg-sign` reference rather than ignoring it — confirmed by temporarily renaming it, which errors:

```
property "gpg-signxx" is not defined in object type
  {build: ...; gpg-sign: {outputs: {}; result: string}}
```

So the hyphenated job id resolves correctly (worth checking — `-` is an operator in GitHub expressions).

## Still inert until secrets exist

`GPG_PRIVATE_KEY` / `GPG_PASSPHRASE` are **not set** on this repo today — only `CARGO_API_TOKEN`, `CARGO_REGISTRY_TOKEN`, `CODECOV_TOKEN`, `SNYK_TOKEN`. That is why `gpg sign · all artifacts` has skipped on every release including v0.0.50. Setting them is a separate, local step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)