### PR TITLE
docs(tests): correct a comment pointing reviewers at a no-op command

### DIFF
--- a/tests/element_presence.rs
+++ b/tests/element_presence.rs
@@ -433,14 +433,26 @@ fn check_core_invariants(
         fail("charset", format!("page {rel}: no charset declared"));
     }
 
-    // meta-description, canonical, og:* chain, twitter:card are
-    // SEO-recommended but not part of the always-on gate. The
-    // bundled `examples/basic` template is intentionally minimal
-    // (single-page demo) and omits them; the other 7 examples
-    // have them via the shared SEO plugins. Reviewers can opt into
-    // the strict check via `cargo test --test element_presence
-    // -- --ignored`, which exercises the full 10-invariant set
-    // including these.
+    // meta-description, canonical, the og:* chain and twitter:card
+    // are deliberately absent from *this* function. They are checked —
+    // always, not opt-in — by [`check_invariants`], which
+    // `every_built_example_page_satisfies_universal_invariants` runs
+    // over the same pages minus [`is_exempt`]. Splitting them this way
+    // keeps `core_invariants_hold_for_every_page` reporting the
+    // structural failures (missing `<h1>`, no `<main>`, no charset)
+    // without burying them under SEO noise.
+    //
+    // `examples/basic` is exempt from the SEO half because its bundled
+    // template is a deliberately minimal single-page demo; every other
+    // example gets those tags from the shared SEO plugins.
+    //
+    // This comment used to end by telling reviewers to opt into a
+    // stricter run with `cargo test --test element_presence --
+    // --ignored`. That command matches nothing: there is no `#[ignore]`
+    // in this file, so it reports `0 passed; 6 filtered out` and looks
+    // like a clean run. The instruction outlived the `#[ignore]` it
+    // referred to. #668 corrected the same claim in
+    // `docs/architecture/regression-contract.md` and missed this copy.
 }
 
 #[test]


### PR DESCRIPTION
## The problem

`check_core_invariants` in `tests/element_presence.rs` ended with:

> Reviewers can opt into the strict check via `cargo test --test element_presence -- --ignored`, which exercises the full 10-invariant set including these.

That command matches nothing. There is no `#[ignore]` anywhere in `tests/element_presence.rs` — the only one in the repository is the 500-page build in `tests/perf_budgets.rs`. Running it prints:

```
running 0 tests
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 6 filtered out
```

A reviewer following that instruction sees `ok` and reasonably concludes the strict invariant set passed. An instruction that silently verifies nothing is worse than no instruction at all.

## It was also wrong about the mechanism

`meta-description`, `canonical`, the `og:*` chain and `twitter:card` are **not opt-in**. `check_invariants` asserts them on every run via `every_built_example_page_satisfies_universal_invariants`. The split between the two functions exists so that `core_invariants_hold_for_every_page` reports structural failures (missing `<h1>`, no `<main>`, no charset) without burying them under SEO noise — it is not a strictness tier.

## Provenance

#668 corrected this same claim in `docs/architecture/regression-contract.md` and missed the copy living in the test file. The remaining `--ignored` reference in that document (line 121) is a *different* one — it describes the perf gate and is accurate.

Found while auditing for gates that exist but never run, after #677. That audit also confirmed two clean results worth recording:

- Exactly one `#[ignore]` in the repository, and it is legitimately opt-in with a stated reason.
- No second instance of the #676 defect. All 18 examples were built and run; the scanned tree (`examples/*/public`) held at **407 HTML files before and after** running the nine examples not covered by `example_outputs.rs` — five write to tempdirs outside the repo, four emit no site.

## Scope

Comment only. No behavioural change.

## Verification

Run in an isolated git worktree on a clean checkout of `main`, with every example built and run first:

```
example_outputs       20/20      element_presence      6/6
audit_gates           40/40      golden_files         17/17
cli_subcommands       16/16      docs_accuracy        12/12
schema_validation      8/8       regression_user_site  7/7
doc_links              4/4       release_versions      4/4
json_feed_compliance   3/3       perf_budgets          2/2 (+1 justified ignore)
jsonld_validation      1/1
cargo clippy --workspace --all-targets --all-features   clean
cargo fmt --all --check                                 clean
```