### PR TITLE
test(ci): fail gates that scan nothing, and let Miri fail the build

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -56,9 +56,14 @@ jobs:
     # the v0.0.45 lift pushed the lib suite to ~2500 tests. 180-minute
     # cap leaves head-room for future test growth without re-tuning.
     timeout-minutes: 180
-    # Advisory window: first 30 days after #560 lands. Drop this once
-    # the `.miri-skip` allowlist stabilises and Miri is reliably green.
-    continue-on-error: true
+    # `continue-on-error` used to sit here as an advisory window for the
+    # first 30 days after #560 landed, to be dropped "once the
+    # `.miri-skip` allowlist stabilises and Miri is reliably green".
+    # #560 shipped in the v0.0.45 cycle, so the window closed months
+    # ago, and the last 60 runs contain 6 successes, 8 concurrency
+    # cancellations and zero failures. Left in place it would have made
+    # this job permanently advisory by accident — a UB detector that
+    # cannot fail the build reports nothing.
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/tests/element_presence.rs
+++ b/tests/element_presence.rs
@@ -45,6 +45,39 @@
 
 use std::{fs, path::Path};
 
+/// Handles the "nothing to scan" case for a gate that reads built
+/// example output.
+///
+/// Locally this is a convenience: `cargo test --test element_presence`
+/// on a fresh clone should say what to run rather than fail. Under
+/// `CI` it is a failure, because a gate that scans zero pages and
+/// reports `ok` is indistinguishable from one that scanned everything
+/// and found nothing wrong.
+///
+/// That distinction is not hypothetical. `examples/multilingual_full`
+/// carried 125 invariant violations for months while this suite
+/// reported success on every run, because nothing in CI populated its
+/// `public/` directory (#676). The gate was green and blind.
+///
+/// Returns `true` when the caller should return early.
+fn bail_on_empty(gate: &str, count: usize) -> bool {
+    if count > 0 {
+        return false;
+    }
+    let msg = format!(
+        "[{gate}] no built example output found under examples/*/public \
+         — run `cargo build --examples && cargo test --test \
+         example_outputs` first to populate."
+    );
+    assert!(
+        std::env::var_os("CI").is_none(),
+        "{msg}\n\nThis is a hard failure under CI: a gate that scans \
+         nothing must not report success."
+    );
+    eprintln!("{msg} Skipping (local run).");
+    true
+}
+
 fn collect_html(dir: &Path, out: &mut Vec<std::path::PathBuf>) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
@@ -292,12 +325,7 @@ fn every_built_example_page_satisfies_universal_invariants() {
         }
     }
 
-    if html_files.is_empty() {
-        eprintln!(
-            "[element_presence] no built example output found under \
-             examples/*/public — run `cargo build --examples && cargo \
-             test --test example_outputs` first to populate. Skipping."
-        );
+    if bail_on_empty("element_presence", html_files.len()) {
         return;
     }
 
@@ -470,11 +498,7 @@ fn core_invariants_hold_for_every_page() {
         }
     }
 
-    if html_files.is_empty() {
-        eprintln!(
-            "[element_presence] no built example output found — \
-             skipping core invariants. Run example_outputs first."
-        );
+    if bail_on_empty("element_presence/core", html_files.len()) {
         return;
     }
 

--- a/tests/jsonld_validation.rs
+++ b/tests/jsonld_validation.rs
@@ -49,13 +49,22 @@ fn every_jsonld_block_in_built_examples_is_valid() {
         }
     }
 
+    // Locally a convenience; under CI a failure. A gate that validates
+    // zero documents and reports `ok` looks exactly like one that
+    // validated everything. `examples/multilingual_full` shipped 37
+    // invalid `WebPage` blocks past this very test for months, because
+    // nothing in CI populated its `public/` directory (#676).
     if html_files.is_empty() {
-        eprintln!(
-            "[jsonld_validation] no built example output found under \
-             examples/*/public — run `cargo build --examples && \
-             cargo test --test example_outputs` first to populate. \
-             Skipping (this is not a failure)."
+        let msg = "[jsonld_validation] no built example output found \
+                   under examples/*/public — run `cargo build \
+                   --examples && cargo test --test example_outputs` \
+                   first to populate.";
+        assert!(
+            std::env::var_os("CI").is_none(),
+            "{msg}\n\nThis is a hard failure under CI: a gate that \
+             validates nothing must not report success."
         );
+        eprintln!("{msg} Skipping (local run).");
         return;
     }
 


### PR DESCRIPTION
Two ways this repository could report success without checking anything. Both found while auditing after #676.

## 1. Gates that pass on an empty scan

`element_presence` (both tests) and `jsonld_validation` returned early with an `eprintln!` — one said, verbatim, *"Skipping (this is not a failure)"* — whenever `examples/*/public` held no HTML.

A gate that scans zero pages and prints `ok` is indistinguishable from one that scanned everything and found nothing wrong.

**That is exactly how #676 survived.** `examples/multilingual_full` carried 125 invariant violations and 37 invalid JSON-LD blocks for months while all three of these tests reported success on every CI run — because nothing in CI populated that example's output.

The early return stays for local runs: `cargo test --test element_presence` on a fresh clone should tell you what to run, not fail. Under `CI` it is now a hard failure.

`tests/doc_links.rs:180` already treats the identical condition as a broken test setup and panics. This brings the other three into line.

### Verified in both directions

That matters more than usual here — a guard that always fires is as useless as one that never does.

| Condition | Result |
|---|---|
| no output, no `CI` | skips, passes — local convenience intact |
| no output, `CI=true` | **3 tests FAIL** — *"a gate that scans nothing must not report success"* |
| 407 pages, `CI=true` | all pass — no false positive |

## 2. Miri could not fail the build

`miri.yml` carried `continue-on-error: true`, commented as:

> Advisory window: first 30 days after #560 lands. Drop this once the `.miri-skip` allowlist stabilises and Miri is reliably green.

#560 shipped in the v0.0.45 cycle, so that window closed months ago and the flag had quietly made the job permanently advisory. The last 60 runs hold **6 successes, 8 concurrency cancellations, zero failures** — reliably green, which was the stated condition for removing it.

A UB detector that cannot fail the build reports nothing.

## Not included, and why

I tried to close Scorecard alert **#241** (`RUSTSEC-2026-0235`) by setting `default-features = false` on `lightningcss`, to drop `sourcemap` → `parcel_sourcemap` → `rkyv 0.7`. **It has no effect**, so I reverted it:

```
$ cargo tree --features minify --invert rkyv
rkyv v0.7.46
└── parcel_sourcemap v2.1.1
    └── lightningcss v1.0.0-alpha.72
        ├── minify-html v0.18.1
        │   └── html-generator → sitemap-gen → staticdatagen → ssg
        └── ssg
```

`minify-html` pulls lightningcss with default features through `staticdatagen`, so feature unification keeps `rkyv` in the graph regardless of what our direct dependency asks for. The advisory needs an upstream fix — lightningcss moving to rkyv 0.8, or minify-html dropping `sourcemap`. The reasoned `deny.toml` ignore remains the correct handling.

## Verification

```
example_outputs      20/20      audit_gates          40/40
golden_files         17/17      cli_subcommands      16/16
docs_accuracy        12/12      schema_validation     8/8
regression_user_site  7/7       element_presence      6/6
doc_links             4/4       release_versions      4/4
json_feed_compliance  3/3       perf_budgets          2/2 (+1 justified ignore)
jsonld_validation     1/1
cargo clippy --workspace --all-targets --all-features   clean
cargo fmt --all --check                                 clean
```

Run in an isolated worktree with all 18 examples built and run first.
