### PR TITLE
test(taxonomy): cover the no-templates renderer, and measure that config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,20 @@ jobs:
           cargo llvm-cov --lib --features test-fault-injection \
             --ignore-filename-regex "$IGNORE" \
             --no-report --quiet
+          # Second pass with default features off.
+          #
+          # `#[cfg(not(feature = "templates"))]` code never compiles into
+          # the pass above, so llvm-cov cannot observe it and every line
+          # in it counts as uncovered on a diff. That made
+          # `codecov/patch` structurally unpassable for any change to
+          # those paths — the `TaxonomyRenderer` fallback renderer being
+          # the case that surfaced it.
+          #
+          # `--no-report` accumulates profraw data, so the `report` calls
+          # below merge both feature configurations into one figure.
+          cargo llvm-cov --lib --no-default-features \
+            --ignore-filename-regex "$IGNORE" \
+            --no-report --quiet
           cargo llvm-cov report --summary-only \
             --ignore-filename-regex "$IGNORE"
           cargo llvm-cov report --lcov --output-path coverage.lcov \

--- a/src/core/lang.rs
+++ b/src/core/lang.rs
@@ -133,7 +133,14 @@ pub(crate) fn normalize_bcp47(raw: &str) -> Option<String> {
     Some(out)
 }
 
-#[cfg(test)]
+// Gated on `templates` to match the items under test: `HashMap` is
+// imported behind that feature (line 41) and `resolve_render_lang` is
+// defined behind it, so without the gate this module does not compile
+// with default features off. It never had one, and nothing noticed —
+// the feature-powerset job runs `cargo check`, which does not build
+// test code, so `cargo test --lib --no-default-features` had simply
+// never been compiled.
+#[cfg(all(test, feature = "templates"))]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;

--- a/src/plugins/taxonomy.rs
+++ b/src/plugins/taxonomy.rs
@@ -1718,6 +1718,8 @@ mod tests {
     /// cannot parse. Falling back to that directory aborted the entire
     /// build with `syntax error: unexpected character (in base.html:26)`,
     /// attributed to `tag.html` — a file the author never wrote.
+    // `resolve_user_template_dir` only exists with `templates` on.
+    #[cfg(feature = "templates")]
     #[test]
     fn user_templates_come_only_from_the_tera_subdirectory() {
         let dir = tempdir().expect("tempdir");
@@ -2285,6 +2287,101 @@ mod tests {
         let value = serde_json::json!("a,,b");
         extract_terms_from_value(&value, &mut map, "T", "/t.html", true);
         assert_eq!(map.len(), 2);
+    }
+
+    // -------------------------------------------------------------------
+    // Fallback renderer — locale handling without the `templates` feature
+    // -------------------------------------------------------------------
+    //
+    // These only compile with default features off, which is the whole
+    // point: that renderer is a separate implementation and used to
+    // ignore `locale` entirely, so a French tree emitted the site's
+    // default language and an un-prefixed canonical. Nothing caught it,
+    // because nothing tested this configuration.
+    //
+    // The coverage job runs a second `--no-default-features` pass so
+    // these are measured rather than counted as dead lines on a diff.
+    #[cfg(not(feature = "templates"))]
+    mod no_templates_renderer {
+        use super::*;
+
+        fn cfg_ctx(base: &PluginContext) -> PluginContext {
+            let cfg = crate::cmd::SsgConfig::builder()
+                .site_name("Example".to_string())
+                .base_url("https://example.com".to_string())
+                .build()
+                .expect("config");
+            PluginContext::with_config(
+                &base.content_dir,
+                &base.build_dir,
+                &base.site_dir,
+                &base.template_dir,
+                cfg,
+            )
+        }
+
+        #[test]
+        fn default_locale_keeps_the_site_language_and_bare_canonical() {
+            let (_tmp, _site, _meta, base) = make_layout();
+            let ctx = cfg_ctx(&base);
+            let renderer = TaxonomyRenderer::new(&ctx);
+
+            assert_eq!(renderer.locale_path_segment(), "");
+            assert_eq!(
+                renderer.canonical("/tags/rust/"),
+                r#"<link rel="canonical" href="https://example.com/tags/rust/">"#
+            );
+        }
+
+        #[test]
+        fn scoped_locale_overrides_language_and_prefixes_canonical() {
+            let (_tmp, _site, _meta, base) = make_layout();
+            let ctx = cfg_ctx(&base);
+            let renderer = TaxonomyRenderer::new(&ctx).for_locale(
+                Some("fr"),
+                "/fr",
+                "/fr",
+            );
+
+            assert_eq!(renderer.lang(), "fr");
+            assert_eq!(renderer.locale_path_segment(), "/fr");
+            assert_eq!(
+                renderer.canonical("/tags/rust/"),
+                r#"<link rel="canonical" href="https://example.com/fr/tags/rust/">"#,
+                "canonical must point at the file actually written"
+            );
+        }
+
+        #[test]
+        fn locale_without_a_language_keeps_the_site_tag() {
+            // `None` marks the default locale. Substituting the bare
+            // locale code here is what turned `en-GB` into `en`.
+            let (_tmp, _site, _meta, base) = make_layout();
+            let cfg = crate::cmd::SsgConfig::builder()
+                .site_name("Example".to_string())
+                .base_url("https://example.com".to_string())
+                .language("en-GB".to_string())
+                .build()
+                .expect("config");
+            let ctx = PluginContext::with_config(
+                &base.content_dir,
+                &base.build_dir,
+                &base.site_dir,
+                &base.template_dir,
+                cfg,
+            );
+            let renderer = TaxonomyRenderer::new(&ctx).for_locale(None, "", "");
+
+            assert_eq!(renderer.lang(), "en-GB");
+        }
+
+        #[test]
+        fn lang_falls_back_to_en_without_a_config() {
+            let (_tmp, _site, _meta, base) = make_layout();
+            let renderer = TaxonomyRenderer::new(&base);
+            assert_eq!(renderer.lang(), "en");
+            assert_eq!(renderer.canonical("/tags/rust/"), "");
+        }
     }
 }
 


### PR DESCRIPTION
Follow-up to #680. That PR's `codecov/patch` check failed at **76.29% against an 80% target**, and no test could have fixed it.

## Why the coverage was unreachable

The coverage job runs:

```
cargo llvm-cov --lib --features test-fault-injection
```

Default features, so `templates` is **on**, and `#[cfg(not(feature = "templates"))]` code never enters the coverage binary at all. Every line of it counts as uncovered on any diff, permanently. #680 changed the fallback `TaxonomyRenderer`, so it took the hit.

Lowering the threshold would have hidden that. This measures the configuration instead.

## 1. The coverage job now measures both configurations

A second `--no-default-features` pass, accumulated with `--no-report` so the existing `report` calls merge both into a single figure. The job already used that pattern; this adds one invocation.

## 2. That configuration's tests had never compiled

Adding the pass failed immediately — and not on anything from #680. **`cargo test --lib --no-default-features` does not build on `main` either:**

- `src/core/lang.rs:41` imports `HashMap` behind `#[cfg(feature = "templates")]`, while its `#[cfg(test)]` module uses both that and the templates-gated `resolve_render_lang` **ungated**.
- `taxonomy::tests::user_templates_come_only_from_the_tera_subdirectory` calls `resolve_user_template_dir`, which only exists with the feature on.

The feature-powerset job runs `cargo check`, which does not build test code — so nothing had ever compiled these. Both are now gated to match the items they exercise.

**3446 lib tests now pass with default features off. That suite had never run.**

## 3. Tests for the fallback renderer

Four, covering the locale behaviour #680 changed:

| Test | Asserts |
|---|---|
| `default_locale_keeps_the_site_language_and_bare_canonical` | no segment, unprefixed canonical |
| `scoped_locale_overrides_language_and_prefixes_canonical` | `lang() == "fr"`, canonical `/fr/tags/rust/` |
| `locale_without_a_language_keeps_the_site_tag` | `en-GB` survives, not flattened to `en` |
| `lang_falls_back_to_en_without_a_config` | `en`, no canonical emitted |

Verified against the pre-fix code, which fails exactly where it should:

```
scoped_locale_overrides_language_and_prefixes_canonical ... FAILED
  left: "en-GB"
 right: "fr"
```

That is the reported symptom — a French tree emitting the site's default language — reproduced as a test.

## Verification

```
cargo test --lib                    3572 passed
cargo test --lib --no-default-features   3446 passed  (first ever run)
cargo hack check --feature-powerset --depth 2   clean, all 45 combinations
cargo clippy --workspace --all-targets --all-features   clean
cargo fmt --all --check             clean
```
