### PR TITLE
fix(determinism): order sidecar and dep-graph keys

### DIFF
--- a/src/core/depgraph.rs
+++ b/src/core/depgraph.rs
@@ -27,7 +27,7 @@
 use crate::error::SsgError;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -59,14 +59,14 @@ pub struct DepGraph {
     #[serde(default = "default_version")]
     version: u32,
     /// `consumer → set<dependency>` (forward edges).
-    deps: HashMap<PathBuf, HashSet<PathBuf>>,
+    deps: BTreeMap<PathBuf, BTreeSet<PathBuf>>,
     /// `source → set<output>`. Used by [`DepGraph::stale_outputs`] to
     /// sweep orphaned output files when a source is deleted (AC5).
     #[serde(default)]
-    outputs: HashMap<PathBuf, HashSet<PathBuf>>,
+    outputs: BTreeMap<PathBuf, BTreeSet<PathBuf>>,
     /// `path → sha256(content)`. The freshness key.
     #[serde(default)]
-    hashes: HashMap<PathBuf, String>,
+    hashes: BTreeMap<PathBuf, String>,
 }
 
 const fn default_version() -> u32 {
@@ -87,12 +87,12 @@ impl DepGraph {
     /// assert_eq!(g.page_count(), 0);
     /// ```
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             version: SCHEMA_VERSION,
-            deps: HashMap::new(),
-            outputs: HashMap::new(),
-            hashes: HashMap::new(),
+            deps: BTreeMap::new(),
+            outputs: BTreeMap::new(),
+            hashes: BTreeMap::new(),
         }
     }
 
@@ -306,7 +306,7 @@ impl DepGraph {
     /// assert!(g.deps_for(Path::new("none")).is_none());
     /// ```
     #[must_use]
-    pub fn deps_for(&self, consumer: &Path) -> Option<&HashSet<PathBuf>> {
+    pub fn deps_for(&self, consumer: &Path) -> Option<&BTreeSet<PathBuf>> {
         self.deps.get(consumer)
     }
 
@@ -323,7 +323,7 @@ impl DepGraph {
     /// assert_eq!(g.outputs_for(Path::new("a.md")).map(|s| s.len()), Some(1));
     /// ```
     #[must_use]
-    pub fn outputs_for(&self, source: &Path) -> Option<&HashSet<PathBuf>> {
+    pub fn outputs_for(&self, source: &Path) -> Option<&BTreeSet<PathBuf>> {
         self.outputs.get(source)
     }
 

--- a/src/core/frontmatter.rs
+++ b/src/core/frontmatter.rs
@@ -9,7 +9,7 @@
 
 use anyhow::{Context, Result};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -100,7 +100,7 @@ pub fn emit_sidecars(content_dir: &Path, sidecar_dir: &Path) -> Result<usize> {
 /// ```
 pub fn read_sidecar(
     html_path: &Path,
-) -> Result<Option<HashMap<String, serde_json::Value>>> {
+) -> Result<Option<BTreeMap<String, serde_json::Value>>> {
     let sidecar = html_path.with_extension("meta.json");
     if !sidecar.exists() {
         return Ok(None);
@@ -109,7 +109,7 @@ pub fn read_sidecar(
     let content = fs::read_to_string(&sidecar).with_context(|| {
         format!("Failed to read sidecar {}", sidecar.display())
     })?;
-    let meta: HashMap<String, serde_json::Value> =
+    let meta: BTreeMap<String, serde_json::Value> =
         serde_json::from_str(&content)?;
     Ok(Some(meta))
 }
@@ -134,7 +134,7 @@ pub fn read_sidecar_for_html(
     html_path: &Path,
     site_dir: &Path,
     sidecar_dir: &Path,
-) -> Result<Option<HashMap<String, serde_json::Value>>> {
+) -> Result<Option<BTreeMap<String, serde_json::Value>>> {
     let rel = html_path.strip_prefix(site_dir).unwrap_or(html_path);
     let sidecar_path = sidecar_dir.join(rel).with_extension("meta.json");
     if !sidecar_path.exists() {
@@ -148,11 +148,11 @@ pub fn read_sidecar_for_html(
     read_sidecar(&sidecar_path.with_extension("").with_extension(""))
 }
 
-/// Converts a `frontmatter_gen::Frontmatter` to a JSON-compatible `HashMap`.
+/// Converts a `frontmatter_gen::Frontmatter` to a JSON-compatible `BTreeMap`.
 pub(crate) fn frontmatter_to_json(
     fm: &frontmatter_gen::Frontmatter,
-) -> HashMap<String, serde_json::Value> {
-    let mut map = HashMap::new();
+) -> BTreeMap<String, serde_json::Value> {
+    let mut map = BTreeMap::new();
     for (key, value) in &fm.0 {
         let _ = map.insert(key.clone(), fm_value_to_json(value));
     }
@@ -230,7 +230,7 @@ mod tests {
 
         let body =
             fs::read_to_string(sidecars.join("index.meta.json")).unwrap();
-        let parsed: HashMap<String, serde_json::Value> =
+        let parsed: BTreeMap<String, serde_json::Value> =
             serde_json::from_str(&body).unwrap();
         assert!(parsed.contains_key("title"));
         assert_eq!(parsed.get("word_count").unwrap().as_u64().unwrap(), 2);
@@ -253,7 +253,7 @@ mod tests {
         assert_eq!(count, 1);
 
         let body = fs::read_to_string(sidecars.join("long.meta.json")).unwrap();
-        let parsed: HashMap<String, serde_json::Value> =
+        let parsed: BTreeMap<String, serde_json::Value> =
             serde_json::from_str(&body).unwrap();
         assert_eq!(parsed.get("word_count").unwrap().as_u64().unwrap(), 450);
         assert_eq!(parsed.get("reading_time").unwrap().as_u64().unwrap(), 2);
@@ -495,7 +495,7 @@ mod tests {
         // Construct a `Value::Object(Box<Frontmatter>)` directly —
         // `Frontmatter` is a tuple struct wrapping `HashMap<String, Value>`,
         // so we can build one by hand. Covers lines 119-124.
-        let mut inner = HashMap::new();
+        let mut inner = std::collections::HashMap::new();
         let _ = inner.insert(
             "k".to_string(),
             frontmatter_gen::Value::String("v".to_string()),


### PR DESCRIPTION
Two builds of the same input produced **33 differing files**. Sorting the
keys of any one of them showed identical content, so the difference was
purely iteration order: `HashMap` randomises it per process, and both
`.meta/*.json` and `.ssg-cache/depgraph.json` were serialised straight out
of one.

That defeats the point of the determinism gate. A reproducible build is
what lets someone check that a published artefact came from the source it
claims to; "the bytes differ but the meaning is the same" is not a property
a verifier can act on.

## Change

`frontmatter_to_json` and the three serialised `DepGraph` fields now use
`BTreeMap`/`BTreeSet`, which iterate in key order. The graph's internal
working sets stay hashed — only what reaches disk needs ordering.

`DepGraph::new` becomes `const`, which clippy asks for now that
`BTreeMap::new` is const where `HashMap::new` was not.

One `HashMap` stays: `frontmatter_gen::Frontmatter` is a tuple struct over
`HashMap` in an external crate, so a test constructing one by hand has to
match that type.

## Verification

Building the four-theme showcase twice:

| | differing files |
|---|---|
| before | 33 |
| after | 4 — all `sbom.cdx.json`, a build timestamp one second apart |
| after, with `SOURCE_DATE_EPOCH` pinned | **0 — byte-identical** |

That last row is the documented reproducible-build path, and it is now
exact.

3,572 lib tests, regression and core suites pass; clippy clean on lib and
all-targets at `-D warnings`; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)