### PR TITLE
feat(taxonomy): --no-tag-pages, for sites that own their own taxonomy

### DIFF
--- a/src/cmd/cli.rs
+++ b/src/cmd/cli.rs
@@ -163,6 +163,15 @@ impl Cli {
                     .value_parser(clap::value_parser!(String)),
             )
             .arg(
+                Arg::new("no_tag_pages")
+                    .help(
+                        "Skip taxonomy (tag/category/topic) page generation",
+                    )
+                    .long("no-tag-pages")
+                    .env("SSG_NO_TAG_PAGES")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
                 Arg::new("validate")
                     .help("Validate content schemas without building")
                     .long("validate")

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -298,6 +298,18 @@ pub struct SsgConfig {
     /// Defaults to `false` to keep zero-JS sites zero-JS.
     #[serde(default)]
     pub transitions: bool,
+    /// Skip generating taxonomy (tag / category / topic) pages.
+    ///
+    /// Defaults to `false`, so a build that does not ask for this is
+    /// unchanged. Sites that curate their own taxonomy — a canonical
+    /// vocabulary, a minimum-article threshold, hand-translated slugs —
+    /// need to own `/tags/` outright: emitting a page per raw
+    /// front-matter term contradicts that curation, and on a
+    /// multi-locale corpus it multiplies the URL surface with thin
+    /// pages. Opting out is cheaper and more honest than deleting the
+    /// output afterwards.
+    #[serde(default)]
+    pub no_taxonomy_pages: bool,
     /// Security tunables (v0.0.47 plan §3 item 2.3): the `[security]`
     /// section of `ssg.toml`. Currently holds the SRI digest
     /// algorithm; absent ⇒ SHA-384.
@@ -340,6 +352,13 @@ impl SsgConfig {
         // If `-s/--serve` was used
         if let Some(serve_dir) = matches.get_one::<PathBuf>("serve") {
             self.serve_dir = Some(serve_dir.clone());
+        }
+
+        // `--no-tag-pages` / SSG_NO_TAG_PAGES. Only ever turns generation
+        // off — absent means the default, so no existing build changes
+        // behaviour merely by upgrading.
+        if matches.get_flag("no_tag_pages") {
+            self.no_taxonomy_pages = true;
         }
 
         // `--watch` flag is handled by the caller (run() in lib.rs)

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -143,6 +143,8 @@ pub fn default_config() -> &'static Arc<SsgConfig> {
             edge_headers: EdgeHeadersConfig::default(),
             agents: None,
             transitions: false,
+            // Default: generate taxonomy pages, as before.
+            no_taxonomy_pages: false,
             security: SecurityConfig::default(),
         })
     })

--- a/src/plugins/postprocess/agentic_discovery/ai_plugin.rs
+++ b/src/plugins/postprocess/agentic_discovery/ai_plugin.rs
@@ -511,6 +511,7 @@ mod fault_tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         }
     }
 

--- a/src/plugins/postprocess/agentic_discovery/ai_plugin.rs
+++ b/src/plugins/postprocess/agentic_discovery/ai_plugin.rs
@@ -271,6 +271,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         }
     }
 

--- a/src/plugins/postprocess/agentic_discovery/mcp.rs
+++ b/src/plugins/postprocess/agentic_discovery/mcp.rs
@@ -400,6 +400,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         }
     }
 

--- a/src/plugins/postprocess/agentic_discovery/mcp.rs
+++ b/src/plugins/postprocess/agentic_discovery/mcp.rs
@@ -823,6 +823,7 @@ mod fault_tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         }
     }
 

--- a/src/plugins/postprocess/atom.rs
+++ b/src/plugins/postprocess/atom.rs
@@ -415,6 +415,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         PluginContext::with_config(
             Path::new("content"),
@@ -1362,6 +1363,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         let ctx = PluginContext::with_config(
             Path::new("content"),
@@ -1584,6 +1586,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         let ctx = PluginContext::with_config(
             Path::new("content"),

--- a/src/plugins/postprocess/json_feed.rs
+++ b/src/plugins/postprocess/json_feed.rs
@@ -440,6 +440,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         PluginContext::with_config(
             Path::new("content"),
@@ -798,6 +799,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         let ctx = PluginContext::with_config(
             Path::new("c"),
@@ -895,6 +897,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         let ctx = PluginContext::with_config(
             Path::new("c"),
@@ -953,6 +956,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         let ctx = PluginContext::with_config(
             Path::new("content"),
@@ -1033,6 +1037,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         PluginContext::with_config(
             Path::new("c"),

--- a/src/plugins/postprocess/news_sitemap.rs
+++ b/src/plugins/postprocess/news_sitemap.rs
@@ -201,6 +201,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         PluginContext::with_config(
             Path::new("content"),

--- a/src/plugins/postprocess/rss.rs
+++ b/src/plugins/postprocess/rss.rs
@@ -331,6 +331,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         PluginContext::with_config(
             Path::new("content"),
@@ -999,6 +1000,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
         let ctx = PluginContext::with_config(
             Path::new("c"),

--- a/src/plugins/taxonomy.rs
+++ b/src/plugins/taxonomy.rs
@@ -1272,7 +1272,10 @@ mod tests {
             .after_compile(&ctx_with_opt_out(&base, true))
             .unwrap();
 
-        assert!(!site.join("tags").exists(), "tags tree written despite opt-out");
+        assert!(
+            !site.join("tags").exists(),
+            "tags tree written despite opt-out"
+        );
         assert!(!site.join("categories").exists());
     }
 

--- a/src/plugins/taxonomy.rs
+++ b/src/plugins/taxonomy.rs
@@ -119,6 +119,14 @@ impl Plugin for TaxonomyPlugin {
     }
 
     fn after_compile(&self, ctx: &PluginContext) -> Result<(), SsgError> {
+        // Opt-out for sites that own their own taxonomy (`--no-tag-pages`
+        // / `SSG_NO_TAG_PAGES`). Checked before any work so the build does
+        // not pay for output it is about to discard. Absent ⇒ generate, so
+        // this cannot change an existing build.
+        if ctx.config.as_ref().is_some_and(|c| c.no_taxonomy_pages) {
+            return Ok(());
+        }
+
         // Sidecar roots in priority order: `<build>/.meta/` (the
         // emit_sidecars convention) and `<site>/.meta/` — the staged
         // copy the real pipeline leaves in the output directory
@@ -1228,6 +1236,66 @@ mod tests {
         TaxonomyPlugin.after_compile(&ctx).unwrap();
         assert!(!site.join("tags").exists());
         assert!(!site.join("categories").exists());
+    }
+
+    // -------------------------------------------------------------------
+    // after_compile — opt-out (`--no-tag-pages` / SSG_NO_TAG_PAGES)
+    // -------------------------------------------------------------------
+
+    /// Builds a context whose config carries `no_taxonomy_pages`.
+    fn ctx_with_opt_out(base: &PluginContext, opt_out: bool) -> PluginContext {
+        let mut cfg = crate::cmd::SsgConfig::builder()
+            .site_name("Example".to_string())
+            .base_url("https://example.com".to_string())
+            .build()
+            .expect("config");
+        cfg.no_taxonomy_pages = opt_out;
+        PluginContext::with_config(
+            &base.content_dir,
+            &base.build_dir,
+            &base.site_dir,
+            &base.template_dir,
+            cfg,
+        )
+    }
+
+    #[test]
+    fn no_taxonomy_pages_suppresses_generation() {
+        let (_tmp, site, meta, base) = make_layout();
+        fs::write(
+            meta.join("p.meta.json"),
+            r#"{"title": "P", "tags": ["rust", "web"], "categories": ["coding"]}"#,
+        )
+        .unwrap();
+
+        TaxonomyPlugin
+            .after_compile(&ctx_with_opt_out(&base, true))
+            .unwrap();
+
+        assert!(!site.join("tags").exists(), "tags tree written despite opt-out");
+        assert!(!site.join("categories").exists());
+    }
+
+    #[test]
+    fn taxonomy_pages_are_generated_by_default() {
+        // The opt-out must be exactly that: absent config, or config with the
+        // flag unset, keeps the pre-existing behaviour. A site that upgrades
+        // without asking for anything sees no change.
+        let (_tmp, site, meta, base) = make_layout();
+        fs::write(
+            meta.join("p.meta.json"),
+            r#"{"title": "P", "tags": ["rust"]}"#,
+        )
+        .unwrap();
+
+        TaxonomyPlugin
+            .after_compile(&ctx_with_opt_out(&base, false))
+            .unwrap();
+
+        assert!(
+            site.join("tags/rust/index.html").exists(),
+            "default must still generate taxonomy pages"
+        );
     }
 
     // -------------------------------------------------------------------

--- a/src/plugins/template_plugin.rs
+++ b/src/plugins/template_plugin.rs
@@ -411,6 +411,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         }
     }
 
@@ -598,6 +599,7 @@ mod tests {
             agents: None,
             transitions: false,
             security: crate::cmd::SecurityConfig::default(),
+            no_taxonomy_pages: false,
         };
 
         let content_dir = config.content_dir.clone();

--- a/tests/agentic_discovery.rs
+++ b/tests/agentic_discovery.rs
@@ -57,6 +57,7 @@ fn base_cfg(agents: Option<AgentsConfig>) -> SsgConfig {
         agents,
         transitions: false,
         security: ssg::cmd::SecurityConfig::default(),
+        no_taxonomy_pages: false,
     }
 }
 

--- a/tests/taxonomy_templated.rs
+++ b/tests/taxonomy_templated.rs
@@ -67,6 +67,7 @@ fn config_with_language(root: &Path, language: &str) -> SsgConfig {
         agents: None,
         transitions: false,
         security: ssg::cmd::SecurityConfig::default(),
+        no_taxonomy_pages: false,
     }
 }
 


### PR DESCRIPTION
Closes #696. Independent of #695 — that is a correctness bug in tag parsing, this is a capability. A site may want this flag with #695 fixed, and vice versa.

## What

An opt-out for taxonomy (tag / category / topic) page generation:

```
ssg --no-tag-pages ...        # or SSG_NO_TAG_PAGES=1
```

backed by a `no_taxonomy_pages` config field. The gate sits at the top of `after_compile`, before any sidecar work, so an opted-out build does not pay for output it would discard.

## Why

Some sites curate tags rather than exposing raw front matter. One 35-locale site declares **825 distinct raw tags in English alone** and collapses them to a canonical taxonomy of **53**, with a ≥3-article threshold before a term earns a landing page — an editorial decision that exists precisely to prevent 1- and 2-article pages.

ssg cannot know that decision exists, so it emits a page per raw term: **~7,172 tag pages against 6,856 real content pages**, roughly doubling the URL surface with the thin half. That site's own generator runs afterwards and overwrites the ~53 that collide, so the curated pages survive — but the remainder is output it never wanted and has to clean up.

## The default does not change

The flag only ever turns generation **off**. Absent ⇒ generate. No existing build changes behaviour by upgrading.

`taxonomy_pages_are_generated_by_default` matters more than the suppression test — it is what keeps this an opt-out rather than an opt-in.

## Verification

Byte-identical output was the acceptance criterion, not "looks right":

| build | files | tag pages |
|---|---|---|
| unpatched HEAD | 37 | 5 |
| patched, flag off | 37 | 5 — **byte-identical to unpatched** |
| patched, `--no-tag-pages` | 32 | 0 — removes exactly those 5, all under `/tags/` |

Two residual diffs were investigated and are not from this change: `news_publication_date` build timestamps (ssg's own fallback, runs seconds apart) and `.meta` key ordering from #694, which reproduces on unpatched HEAD. `search-index.json` differs under the flag, correctly — a suppressed page should not be indexed.

- `cargo test --lib` — **3,574 passed**
- `cargo clippy --all-targets` — 0 findings
- `cargo fmt --check` — clean
- Mutation-checked: removing the gate fails `no_taxonomy_pages_suppresses_generation`

## Note on the second commit

I verified the first commit with `--lib` only and shipped two defects with it — two integration-test literals missing the new field, and a rustfmt diff (a piped `cargo fmt --check | head` swallowed the non-zero exit, so the fallback never ran). The second commit fixes both and re-verifies across all targets. Leaving the history rather than rewriting it, since the mistake is the reason the verification scope changed.

One pre-existing failure remains and is unrelated: `examples/quickstart_example.rs::test_site_generator_creation` fails identically on unpatched HEAD.