### PR TITLE
chore(release): 0.0.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.52] - 2026-08-19
+
+Two tag-handling defects and one capability, all found by building a
+35-locale site against v0.0.50 and v0.0.51.
+
+### ⚠️ Behaviour change
+
+**Tag lists now split on non-ASCII separators.** If any post's `tags:`,
+`categories:` or `topics:` field separates terms with `،` (Arabic comma),
+`，` or `、` (CJK) or `;`, those terms were previously collected as **one**
+term whose name was the entire list. They are now split correctly, so the
+generated tag tree changes shape on upgrade: more terms, each shorter, and
+the old combined term disappears.
+
+This is the fix rather than a regression, but it is a visible output change:
+existing URLs under `tags/` derived from a mis-split term will not be
+regenerated. Sites that publish only ASCII-separated tags are unaffected.
+
+### Fixed
+
+- **A multilingual tag list could kill the build** (#695). Term lists were
+  split on ASCII `,` alone, so a post written in Arabic — which separates
+  with `،` (U+060C) — had its whole list collected as a single term. That
+  term then slugified into one enormous path component: 230 characters, but
+  **348 UTF-8 bytes**, because `is_alphanumeric` is Unicode-aware and
+  non-Latin scripts survive at 2–4 bytes per character. ext4 caps a path
+  component at 255 *bytes*, so the build aborted with
+  `File name too long (os error 36)`. APFS caps at 255 *characters*, so the
+  same site built cleanly on macOS and only Linux CI failed — which is how
+  it shipped. `split_terms` in `ssg-core` now recognises `,` `،` `，` `、`
+  and `;`, and the four call sites that each open-coded `split(',')` share
+  one definition.
+- **`slugify` had no length cap** (#695). Fixed independently of the
+  separator bug, because it is reachable without it: any sufficiently long
+  legitimate term hits the same 255-byte wall. Slugs are now truncated to
+  200 bytes on a character boundary — byte-slicing a multi-byte sequence
+  panics — with a dangling separator trimmed from the cut.
+
+### Added
+
+- **`--no-tag-pages` / `SSG_NO_TAG_PAGES`** (#696), with a
+  `no_taxonomy_pages` config field. Skips taxonomy page generation entirely,
+  for sites that curate their own vocabulary. One 35-locale site declares
+  825 distinct raw tags in English alone and collapses them to a canonical
+  53 with a ≥3-article threshold before a term earns a landing page; ssg
+  cannot know that decision exists and emitted ~7,172 pages against 6,856
+  real content pages, roughly doubling the URL surface with the thin half.
+  **The default is unchanged** — the flag only ever turns generation off, so
+  no existing build changes behaviour by upgrading. Verified byte-identical
+  output with the flag absent.
+
 ## [0.0.51] - 2026-08-16
 
 The follow-through release. Every item below was found by building real

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "ssg"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-a11y"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "serde",
  "serde_json",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-core"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "log",
  "noyalib 0.0.17",
@@ -4911,7 +4911,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "criterion",
  "inventory",
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc-macro"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-search"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4947,7 +4947,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-wasm"
-version = "0.0.51"
+version = "0.0.52"
 dependencies = [
  "js-sys",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "ssg"                            # The name of the library
-version = "0.0.51"                      # The version of the library
+version = "0.0.52"                      # The version of the library
 authors = ["SSG Contributors"]     # The authors of the library
 edition = "2021"                        # The edition of the library
 rust-version = "1.88.0"                 # Minimum supported Rust version (set by time-macros, staticdatagen, oxc_*)
@@ -181,10 +181,10 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["html
 rayon = "1.12.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.51" }
-ssg-core = { path = "crates/ssg-core", version = "0.0.51" }
-ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.51" }
-ssg-search = { path = "crates/ssg-search", version = "0.0.51" }
+ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.52" }
+ssg-core = { path = "crates/ssg-core", version = "0.0.52" }
+ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.52" }
+ssg-search = { path = "crates/ssg-search", version = "0.0.52" }
 thiserror = "2"
 staticdatagen = "0.0.12"
 toml = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.51-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.52-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -41,7 +41,7 @@
 
 ```toml
 [dependencies]
-ssg = "0.0.51"
+ssg = "0.0.52"
 ```
 
 ### Prebuilt binaries

--- a/crates/ssg-a11y/Cargo.toml
+++ b/crates/ssg-a11y/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-a11y"
-version = "0.0.51"
+version = "0.0.52"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-core"
-version = "0.0.51"
+version = "0.0.52"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc-macro"
-version = "0.0.51"
+version = "0.0.52"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc/Cargo.toml
+++ b/crates/ssg-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc"
-version = "0.0.51"
+version = "0.0.52"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ schemars = { version = "1.2", default-features = false, features = ["derive", "s
 thiserror = "2"
 
 # Re-export the proc-macro so users only depend on `ssg-rpc`.
-ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.51" }
+ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.52" }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/ssg-search/Cargo.toml
+++ b/crates/ssg-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-search"
-version = "0.0.51"
+version = "0.0.52"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-wasm/Cargo.toml
+++ b/crates/ssg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-wasm"
-version = "0.0.51"
+version = "0.0.52"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Cuts **0.0.52** with #695 (two fixes) and #696 (`--no-tag-pages`), both already on `main`.

## ⚠️ This release contains a visible output change

**Tag lists now split on non-ASCII separators.** A site whose `tags:` field separates terms with `،` `，` `、` or `;` previously collected the whole list as **one** term. Those now split correctly, so the generated tag tree changes shape on upgrade — more terms, each shorter, and the old combined term disappears.

That is the fix rather than a regression, but it is not a silent bugfix, so the changelog leads with it rather than burying it under "fixes crash". Worth stating explicitly because a `0.0.x` pin protects nobody who bumps by hand — under cargo's rules every `0.0.x` is mutually incompatible anyway, so the pin is not what carries the warning; the notes are.

Sites publishing only ASCII-separated tags are unaffected.

## Contents

- **#695** — the ENAMETOOLONG build failure (Arabic comma → one 348-byte path component; ext4 caps at 255 **bytes** while APFS caps at 255 **characters**, which is why it only ever failed on Linux CI), plus an independently-justified 200-byte slug cap that protects any long legitimate term.
- **#696** — `--no-tag-pages` / `SSG_NO_TAG_PAGES`. Default unchanged; verified byte-identical output with the flag absent.

## Verification

Run with CI's own commands rather than an approximation of them:

```
cargo fmt --all -- --check                        clean
cargo clippy --lib --all-features -- -D warnings  pass
cargo test --lib --all-features                   3,620 passed
```

12 version pins bumped across the workspace; `cargo check` resolves.

Behaviour re-confirmed on merged `main` before tagging: default build splits the Arabic fixture into 4 tags (longest 33 bytes, previously 1 of 130), and `--no-tag-pages` emits no `/tags/` at all.