### PR TITLE
fix(ci): stop windows-latest timing out, by undoing what slowed it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,12 +147,20 @@ jobs:
     name: test · ${{ matrix.os }}
     needs: lint
     runs-on: ${{ matrix.os }}
-    # Bumped from 8 → 15 in v0.0.42 because the new tests (ravif AVIF
-    # encoding in particular — ~1.2s per 1024×768 image on the runner)
-    # push lib-test wall-time past the prior ceiling on ubuntu/windows.
-    # macos-latest happens to be on a faster M-series runner and stayed
-    # under 8m. Long-term: triage slow tests behind a `slow` feature flag.
-    timeout-minutes: 15
+    # Bumped 8 → 15 in v0.0.42 (ravif AVIF encoding, ~1.2s per 1024×768
+    # image on the runner) and 15 → 20 after windows-latest started being
+    # cancelled at exactly 15m00s.
+    #
+    # Almost all of that is compilation, not tests: on the run that hit
+    # the ceiling, Windows finished 3,491 lib tests in 35s having already
+    # spent ~14m50s building. A cancelled job therefore says nothing
+    # about the code, which is the worst kind of red — it reads as a test
+    # failure and is not one.
+    #
+    # Observed Windows wall-time is 9-10m on a warm cache and 14-15m cold,
+    # so 15 left no margin for ordinary variance. 20 absorbs that while
+    # still failing a genuinely hung job.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -451,21 +451,6 @@ path = "examples/agent_api_example.rs"
 [lints]
 workspace = true
 
-# Dependencies are built optimised even in dev/test builds.
-#
-# Profiling the 500-page budget showed 94% of wall-clock inside
-# `staticdatagen::compile` — a dependency — with our own staging at ~6%.
-# In an unoptimised dev build that third-party code runs at roughly a
-# quarter of its real speed, so `cargo test` was measuring a slowness no
-# user ever experiences: `ssg` ships from the release profile.
-#
-# Optimising only `*` (dependencies) keeps our own crate unoptimised, so
-# backtraces, debug-assertions and step-debugging in ssg code are
-# unaffected. The cost is a one-off longer dependency compile, cached
-# thereafter.
-[profile.dev.package."*"]
-opt-level = 2
-
 [profile.dev]
 # Development profile configuration for fast builds and debugging.
 codegen-units = 16                          # Balance between compile speed and disk usage (256 creates massive target dirs)


### PR DESCRIPTION
`test · windows-latest` had been reporting **"cancelled"** on every run.
Not flaky infrastructure, not a test failure: the job was hitting its
15-minute ceiling, which GitHub reports as a cancellation.

On the run that exposed it, Windows finished **3,491 lib tests in 35
seconds** having already spent ~14m50s compiling. So a red Windows job was
saying nothing whatsoever about the code — the worst kind of red, because
it reads as a test failure and is not one.

## The cause was mine

v0.0.51 added `[profile.dev.package."*"] opt-level = 2`, optimising every
dependency in dev and test builds:

```
before v0.0.51:   9m,  10m,  10m
after  v0.0.51:  14m,  15m (cancelled),  15m
```

I added that profile while chasing the benchmark target, because 94% of a
500-page build sat inside an unoptimised `staticdatagen::compile` and the
budget was measuring a slowness no user experiences. It bought benchmark
accuracy and paid for it in compile time on every machine, CI included.

**It is no longer needed.** staticdatagen 0.0.12 renders and writes across
cores, so the speed now comes from the code rather than the profile.
Measured with the profile removed:

| Pages | v0.0.50 | now | faster | budget | headroom |
|-------|---------|-----|--------|--------|----------|
|   100 |  387.7ms |  148.8ms | 61.6% |  800ms | 5.4x |
|   500 | 2,830 ms |  738.0ms | 73.9% | 2000ms | 2.7x |

Still far beyond the 50% this work was aiming at, and the 500-page budget
keeps 2.7x headroom where it previously had none.

## The ceiling was too tight anyway

Even before v0.0.51, Windows ran 9-10m against a 15m limit — about a third
of margin, on a job whose time is dominated by a compile whose duration
depends on cache state. Raised to 20m: enough to absorb ordinary variance,
still short enough to fail a genuinely hung job. The comment now records
the observed range and that the time is compilation rather than tests, so
the next person reading a cancelled job knows what it means.

## Verification

Perf budgets pass in the CI configuration, 3,572 lib tests pass, clippy
clean at `-D warnings`, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)