### PR TITLE
docs(core): state the values instead of linking private constants

### DIFF
--- a/crates/ssg-core/src/lib.rs
+++ b/crates/ssg-core/src/lib.rs
@@ -345,8 +345,9 @@ const TERM_SEPARATORS: [char; 5] = [
 
 /// Splits a front-matter term list into trimmed, non-empty terms.
 ///
-/// Accepts every separator in [`TERM_SEPARATORS`], so a tag list keeps its
-/// terms whatever script it was written in.
+/// Accepts a comma or semicolon, plus the Arabic comma (`،`), fullwidth
+/// comma (`，`) and ideographic comma (`、`), so a tag list keeps its terms
+/// whatever script it was written in.
 ///
 /// # Examples
 ///
@@ -382,8 +383,8 @@ const MAX_SLUG_BYTES: usize = 200;
 ///
 /// Lowercases ASCII letters, replaces non-alphanumeric runs with a
 /// single `-`, and trims leading/trailing separators. The result is
-/// truncated to [`MAX_SLUG_BYTES`] bytes on a character boundary, so a
-/// slug is always a legal path component on Linux filesystems.
+/// truncated to 200 bytes on a character boundary, so a slug is always a
+/// legal path component on Linux filesystems.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
The **📚 Document** workflow has been failing on `main`. The command it
runs — `cargo doc --no-deps --all-features --workspace` — errors on two
intra-doc links from public documentation to private items:

```
error: public documentation for `split_terms` links to private item `TERM_SEPARATORS`
error: public documentation for `slugify` links to private item `MAX_SLUG_BYTES`
```

The links were unhelpful even setting rustdoc aside. A reader of the public
docs cannot navigate to a private constant, and the constant's *name* tells
them nothing — what they want to know is which separators are accepted and
how long a slug can be.

So the docs now say it directly: `split_terms` lists the separators (comma,
semicolon, Arabic comma, fullwidth comma, ideographic comma) and `slugify`
gives the 200-byte limit outright.

No API change. Making the constants `pub` would have satisfied the link by
widening the public surface for two implementation details.

## Verification

`cargo doc --no-deps --all-features --workspace` exits 0 with 0 errors,
where it previously failed. ssg-core tests pass, clippy clean at
`-D warnings`, fmt clean.

Note this only shows up with `--workspace`; `cargo doc --no-deps` alone
passes, which is presumably how it went unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)