### PR TITLE
fix(cli): accept 1/yes/on for SSG_NO_TAG_PAGES

### DIFF
--- a/src/cmd/cli.rs
+++ b/src/cmd/cli.rs
@@ -73,6 +73,22 @@ pub enum CliInvocation {
     Legacy,
 }
 
+/// Parses a boolean-ish environment value for a `SetTrue` flag.
+///
+/// clap's default bool parser accepts only `true`/`false`, but an env var is
+/// conventionally set to `1`, `yes` or `on`. Anything unrecognised is an
+/// error rather than a silent false: a typo'd `SSG_NO_TAG_PAGES=ture` should
+/// say so, not quietly generate the pages the operator asked to skip.
+fn parse_env_bool(s: &str) -> Result<bool, String> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" | "" => Ok(false),
+        other => Err(format!(
+            "expected a boolean (1/true/yes/on or 0/false/no/off), got {other:?}"
+        )),
+    }
+}
+
 impl Cli {
     /// Builds the legacy flag-style `clap::Command`.
     ///
@@ -169,6 +185,13 @@ impl Cli {
                     )
                     .long("no-tag-pages")
                     .env("SSG_NO_TAG_PAGES")
+                    // `SetTrue` parses the env var as a *value*, and its
+                    // default parser accepts only "true"/"false" — so the
+                    // conventional `SSG_NO_TAG_PAGES=1` was rejected with
+                    // `invalid value '1'`, taking the whole build down. The
+                    // flag form was unaffected, which is how this shipped
+                    // with the release notes advertising `=1`.
+                    .value_parser(parse_env_bool)
                     .action(ArgAction::SetTrue),
             )
             .arg(
@@ -568,6 +591,28 @@ impl Cli {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+
+    #[test]
+    fn env_bool_accepts_conventional_truthy_values() {
+        // Regression: `SetTrue` + `.env()` parses the variable as a value,
+        // and clap's default bool parser rejects everything but true/false.
+        // `SSG_NO_TAG_PAGES=1` therefore aborted the build with
+        // `invalid value '1'` — shipped in 0.0.52 with the release notes
+        // advertising exactly that form.
+        for v in ["1", "true", "TRUE", "yes", "on", " on "] {
+            assert_eq!(parse_env_bool(v), Ok(true), "{v:?}");
+        }
+        for v in ["0", "false", "no", "off", ""] {
+            assert_eq!(parse_env_bool(v), Ok(false), "{v:?}");
+        }
+    }
+
+    #[test]
+    fn env_bool_rejects_garbage_rather_than_defaulting_false() {
+        // A typo must not silently produce the opposite of what was asked.
+        assert!(parse_env_bool("ture").is_err());
+        assert!(parse_env_bool("maybe").is_err());
+    }
 
     use super::*;
 


### PR DESCRIPTION
`SSG_NO_TAG_PAGES=1` — the conventional way to set a boolean env var — **aborts the build**:

```
error: invalid value '1' for '--no-tag-pages'
  [possible values: true, false]
```

`ArgAction::SetTrue` combined with `.env()` makes clap parse the variable as a *value*, and its default bool parser accepts only `true`/`false`.

## Why this shipped in 0.0.52

The **flag** form was unaffected, so `--no-tag-pages` passed every test I wrote — while the env var those same notes advertise was never exercised. Found by using it on a real site immediately after release, not by reading the code.

## Fix

A value parser accepting `1/true/yes/on` and `0/false/no/off`, case- and whitespace-insensitive.

Anything unrecognised is an **error**, not a silent false. `SSG_NO_TAG_PAGES=ture` should say so rather than quietly generating the tag pages the operator asked to skip — a wrong-but-plausible default is worse than a loud failure.

## Verified on real builds

| value | outcome |
|---|---|
| `1`, `true`, `yes`, `on` | tag tree suppressed |
| `0`, `false`, empty | tag tree generated |
| `ture` | `error: … expected a boolean (1/true/yes/on or 0/false/no/off)` |

Two regression tests. `fmt` clean; clippy clean on both CI invocations (`--lib --all-features -D warnings` and `--lib --tests --examples --all-features`); **3,622 tests pass**.

Worth a 0.0.53 — 0.0.52's env form is broken as released.