### PR TITLE
chore(release): 0.0.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.53] - 2026-08-20
+
+A one-line fix for a defect shipped in 0.0.52.
+
+### Fixed
+
+- **`SSG_NO_TAG_PAGES=1` aborted the build** (#702). `--no-tag-pages` used
+  `ArgAction::SetTrue` together with `.env()`. clap parses an environment
+  variable as a *value*, and its default bool parser accepts only
+  `"true"`/`"false"`, so the conventional form failed outright:
+
+      error: invalid value '1' for '--no-tag-pages'
+        [possible values: true, false]
+
+  The flag form was unaffected, which is exactly why 0.0.52 shipped this way:
+  `--no-tag-pages` was tested thoroughly and the environment variable
+  advertised alongside it was never exercised end to end. It surfaced within
+  minutes of using the feature on a real site.
+
+  The variable now accepts `1`/`true`/`yes`/`on` and `0`/`false`/`no`/`off`,
+  case- and whitespace-insensitive. An unrecognised value is an **error**
+  rather than a silent false — `SSG_NO_TAG_PAGES=ture` should say so, not
+  quietly generate the pages the operator asked to skip.
+
+  Anyone using the environment variable from 0.0.52 needs this release; the
+  `--no-tag-pages` flag works in both.
+
 ## [0.0.52] - 2026-08-19
 
 Two tag-handling defects and one capability, all found by building a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "ssg"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-a11y"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "serde",
  "serde_json",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-core"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "log",
  "noyalib 0.0.17",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "criterion",
  "inventory",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc-macro"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-search"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4942,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-wasm"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "js-sys",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "ssg"                            # The name of the library
-version = "0.0.52"                      # The version of the library
+version = "0.0.53"                      # The version of the library
 authors = ["SSG Contributors"]     # The authors of the library
 edition = "2021"                        # The edition of the library
 rust-version = "1.88.0"                 # Minimum supported Rust version (set by time-macros, staticdatagen, oxc_*)
@@ -181,10 +181,10 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["html
 rayon = "1.12.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.52" }
-ssg-core = { path = "crates/ssg-core", version = "0.0.52" }
-ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.52" }
-ssg-search = { path = "crates/ssg-search", version = "0.0.52" }
+ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.53" }
+ssg-core = { path = "crates/ssg-core", version = "0.0.53" }
+ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.53" }
+ssg-search = { path = "crates/ssg-search", version = "0.0.53" }
 thiserror = "2"
 staticdatagen = "0.0.12"
 toml = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.52-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.53-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -41,7 +41,7 @@
 
 ```toml
 [dependencies]
-ssg = "0.0.52"
+ssg = "0.0.53"
 ```
 
 ### Prebuilt binaries

--- a/crates/ssg-a11y/Cargo.toml
+++ b/crates/ssg-a11y/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-a11y"
-version = "0.0.52"
+version = "0.0.53"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-core"
-version = "0.0.52"
+version = "0.0.53"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc-macro"
-version = "0.0.52"
+version = "0.0.53"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc/Cargo.toml
+++ b/crates/ssg-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc"
-version = "0.0.52"
+version = "0.0.53"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ schemars = { version = "1.2", default-features = false, features = ["derive", "s
 thiserror = "2"
 
 # Re-export the proc-macro so users only depend on `ssg-rpc`.
-ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.52" }
+ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.53" }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/ssg-search/Cargo.toml
+++ b/crates/ssg-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-search"
-version = "0.0.52"
+version = "0.0.53"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-wasm/Cargo.toml
+++ b/crates/ssg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-wasm"
-version = "0.0.52"
+version = "0.0.53"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Ships #702, already on `main`.

## Why this release exists

**0.0.52 shipped with `SSG_NO_TAG_PAGES=1` aborting the build.**

```
error: invalid value '1' for '--no-tag-pages'
  [possible values: true, false]
```

`ArgAction::SetTrue` with `.env()` makes clap parse the variable as a *value*, and its default bool parser accepts only `true`/`false`.

The `--no-tag-pages` **flag** was unaffected — which is precisely why this shipped. The flag was tested thoroughly; the environment variable advertised alongside it was never exercised end to end. It surfaced within minutes of using the feature on a real site, not from reading the code.

Anyone using the env form from 0.0.52 needs this release. The flag form works in both.

## Contents

- `1`/`true`/`yes`/`on` and `0`/`false`/`no`/`off`, case- and whitespace-insensitive
- an unrecognised value is an **error**, not a silent false — `SSG_NO_TAG_PAGES=ture` must say so rather than quietly generating the pages the operator asked to skip

## Verification

12 version pins **plus both README version claims**. The README is what the `docs_accuracy` gate caught during the 0.0.52 release; checked green here *before* pushing rather than after CI complained:

```
docs_accuracy                                     12 passed
cargo fmt --all -- --check                        clean
cargo clippy --lib --all-features -- -D warnings  pass
cargo clippy --lib --tests --examples --all-features  pass
```