### PR TITLE
fix(seo,config): two placeholder/escaping defects that reached rendered pages

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -107,9 +107,32 @@ pub const RESERVED_NAMES: &[&str] =
 pub const MAX_CONFIG_SIZE: usize = 1024 * 1024; // 1MB limit
 
 /// Default site name for the configuration.
+///
+/// Used for the scaffold directory name (`ssg --new`), never rendered into a
+/// page. Contrast [`DEFAULT_SITE_TITLE`], which is.
 pub const DEFAULT_SITE_NAME: &str = "MySsgSite";
-/// Default site title for the configuration.
-pub const DEFAULT_SITE_TITLE: &str = "My SSG Site";
+
+/// Default site title for the configuration — deliberately empty.
+///
+/// This value **reaches rendered HTML**: the taxonomy plugin puts it in
+/// `site.title`, and `templates/tera/base.html` appends it to every page
+/// title as `<title>{page} — {site.title}</title>`.
+///
+/// It used to be `"My SSG Site"`. A site built without a config file therefore
+/// shipped that placeholder as its brand — on sebastienrousseau.com it reached
+/// 7,189 generated tag pages, each titled `Tag: <term> — My SSG Site`, live and
+/// indexable. Nothing caught it because the defaults were only ever asserted
+/// *equal to their own constant*; no test asked whether they escaped into
+/// output.
+///
+/// Empty is the safe default: `base.html` guards the suffix with
+/// `{% if site.title %}`, so an unconfigured build now renders `<title>{page}</title>`
+/// and brands nothing. Sites that want a suffix set `site_title` explicitly,
+/// and `ssg` warns when it falls back to defaults.
+///
+/// See `tests/no_placeholder_in_output.rs`, which fails if any placeholder
+/// constant appears anywhere in a rendered site.
+pub const DEFAULT_SITE_TITLE: &str = "";
 
 /// A static default configuration for the SSG site.
 pub static DEFAULT_CONFIG: OnceLock<Arc<SsgConfig>> = OnceLock::new();

--- a/src/core/content_stager.rs
+++ b/src/core/content_stager.rs
@@ -150,7 +150,7 @@ pub fn stage_content_with_template_defaults(
 /// fs::write(src.join("post.md"), "---\ntitle: A\n---\nbody").unwrap();
 ///
 /// let staged = stage_content_with_site_defaults(
-///     &src, &build, &[], Some("https://example.com"),
+///     &src, &build, &[], Some("https://example.com"), &[],
 /// ).unwrap();
 /// let out = fs::read_to_string(staged.join("post.md")).unwrap();
 /// assert!(out.contains("permalink: \"https://example.com/post/\""));

--- a/src/core/schema.rs
+++ b/src/core/schema.rs
@@ -68,8 +68,8 @@ pub fn generate_schema() -> Value {
             },
             "site_title": {
                 "type": "string",
-                "description": "Title of the site.",
-                "default": "My SSG Site"
+                "description": "Title of the site. The default templates append it to every page title, so it defaults to empty rather than a placeholder: an unset title brands nothing instead of branding every page \"My SSG Site\". See DEFAULT_SITE_TITLE.",
+                "default": ""
             },
             "site_description": {
                 "type": "string",
@@ -187,7 +187,7 @@ mod tests {
         assert_eq!(props["output_dir"]["default"], "public");
         assert_eq!(props["template_dir"]["default"], "templates");
         assert_eq!(props["base_url"]["default"], "http://127.0.0.1:8000");
-        assert_eq!(props["site_title"]["default"], "My SSG Site");
+        assert_eq!(props["site_title"]["default"], "");
         assert_eq!(
             props["site_description"]["default"],
             "A site built with SSG"

--- a/src/plugins/taxonomy.rs
+++ b/src/plugins/taxonomy.rs
@@ -1325,6 +1325,135 @@ mod tests {
         assert!(html.contains("Untitled"));
     }
 
+    // -------------------------------------------------------------------
+    // Placeholder defaults must never reach a rendered page
+    // -------------------------------------------------------------------
+
+    /// A config that leaves `site_title` unset must not brand the tag pages.
+    ///
+    /// This is the bug: `builtin_templates/tag.html` renders
+    /// `Tag: {{ tag }}{% if site.title %} — {{ site.title }}{% endif %}`, and
+    /// `DEFAULT_SITE_TITLE` used to be `"My SSG Site"`. Any site built without
+    /// an explicit `site_title` therefore titled every generated tag page
+    /// `Tag: <term> — My SSG Site`. On sebastienrousseau.com that shipped
+    /// 7,189 such pages, live and indexable.
+    ///
+    /// Nothing caught it because the defaults were only ever asserted equal to
+    /// their own constant — `assert_eq!(props["site_title"]["default"], "My
+    /// SSG Site")` — which pins the placeholder as correct rather than asking
+    /// whether it escapes into output.
+    #[test]
+    fn tag_page_never_renders_a_placeholder_site_title() {
+        let (_tmp, site, meta, base) = make_layout();
+        fs::write(
+            meta.join("p.meta.json"),
+            r#"{"title": "P", "tags": ["rust"]}"#,
+        )
+        .unwrap();
+
+        // Exactly the bug condition: a valid config that never sets
+        // site_title, so whatever DEFAULT_SITE_TITLE holds is rendered.
+        let cfg = crate::cmd::SsgConfig::builder()
+            .site_name("Example".to_string())
+            .base_url("https://example.com".to_string())
+            .build()
+            .expect("config");
+        let ctx = PluginContext::with_config(
+            &base.content_dir,
+            &base.build_dir,
+            &base.site_dir,
+            &base.template_dir,
+            cfg,
+        );
+
+        TaxonomyPlugin.after_compile(&ctx).unwrap();
+        let html =
+            fs::read_to_string(site.join("tags/rust/index.html")).unwrap();
+
+        for placeholder in ["My SSG Site", "MySsgSite", "A site built with SSG"]
+        {
+            assert!(
+                !html.contains(placeholder),
+                "generated tag page rendered the placeholder {placeholder:?}; \
+                 an unconfigured site must brand nothing.\nRendered:\n{html}"
+            );
+        }
+    }
+
+    /// The positive control: an explicitly configured title *is* rendered.
+    ///
+    /// Without this, emptying the default would "pass" even if the suffix had
+    /// been deleted from the template outright, which would silently drop a
+    /// feature configured sites rely on.
+    #[test]
+    fn tag_page_renders_a_configured_site_title() {
+        let (_tmp, site, meta, base) = make_layout();
+        fs::write(
+            meta.join("p.meta.json"),
+            r#"{"title": "P", "tags": ["rust"]}"#,
+        )
+        .unwrap();
+
+        let cfg = crate::cmd::SsgConfig::builder()
+            .site_name("Example".to_string())
+            .site_title("Sebastien Rousseau".to_string())
+            .base_url("https://example.com".to_string())
+            .build()
+            .expect("config");
+        let ctx = PluginContext::with_config(
+            &base.content_dir,
+            &base.build_dir,
+            &base.site_dir,
+            &base.template_dir,
+            cfg,
+        );
+
+        TaxonomyPlugin.after_compile(&ctx).unwrap();
+        let html =
+            fs::read_to_string(site.join("tags/rust/index.html")).unwrap();
+        assert!(
+            html.contains("Sebastien Rousseau"),
+            "a configured site_title must still reach the tag page"
+        );
+    }
+
+    /// Terms separated by a non-ASCII comma must split into separate tags.
+    ///
+    /// Splitting on ASCII `,` alone collapsed an Arabic or Japanese tag list
+    /// into one enormous term, which slugified into a single path component
+    /// long enough to hit ENAMETOOLONG on ext4 while succeeding on APFS —
+    /// a Linux-only build failure no contributor could reproduce locally.
+    #[test]
+    fn tag_lists_split_on_the_comma_of_their_own_script() {
+        let (_tmp, site, meta, ctx) = make_layout();
+        fs::write(
+            meta.join("intl.meta.json"),
+            r#"{"title": "Intl", "tags": "\u0627\u0644\u0645\u0635\u0631\u0641\u064a\u0629\u060c \u0627\u0644\u0645\u062f\u0641\u0648\u0639\u0627\u062a"}"#,
+        )
+        .unwrap();
+
+        TaxonomyPlugin.after_compile(&ctx).unwrap();
+
+        let tags = site.join("tags");
+        let count = fs::read_dir(&tags).map(Iterator::count).unwrap_or(0);
+        assert!(
+            count >= 2,
+            "an Arabic-comma tag list must split into separate terms, got \
+             {count} director(y|ies) under {}",
+            tags.display()
+        );
+        for entry in fs::read_dir(&tags).unwrap().flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            assert!(
+                name.len() <= 200,
+                "slug {name:?} is {} bytes; path components are capped at 255 \
+                 bytes on ext4 and slugify caps at 200",
+                name.len()
+            );
+        }
+    }
+
     #[test]
     fn after_compile_ignores_non_string_tag_values() {
         let (_tmp, site, meta, ctx) = make_layout();

--- a/src/plugins/taxonomy.rs
+++ b/src/plugins/taxonomy.rs
@@ -1435,7 +1435,7 @@ mod tests {
         TaxonomyPlugin.after_compile(&ctx).unwrap();
 
         let tags = site.join("tags");
-        let count = fs::read_dir(&tags).map(Iterator::count).unwrap_or(0);
+        let count = fs::read_dir(&tags).map_or(0, Iterator::count);
         assert!(
             count >= 2,
             "an Arabic-comma tag list must split into separate terms, got \

--- a/src/plugins/taxonomy.rs
+++ b/src/plugins/taxonomy.rs
@@ -651,6 +651,22 @@ impl<'a> TaxonomyRenderer<'a> {
         }
     }
 
+    /// ` — <site title>` when one is configured, else empty.
+    ///
+    /// Mirrors `{% if site.title %} — {{ site.title }}{% endif %}` in the
+    /// bundled templates. Without this the no-templates build silently
+    /// dropped a configured title, so the same config produced differently
+    /// branded pages depending on which features the binary was built with.
+    fn site_title_suffix(&self) -> String {
+        self.ctx.config.as_ref().map_or_else(String::new, |cfg| {
+            if cfg.site_title.is_empty() {
+                String::new()
+            } else {
+                format!(" \u{2014} {}", cfg.site_title)
+            }
+        })
+    }
+
     fn render_term_page(
         &self,
         _kind: TaxonomyKind,
@@ -665,6 +681,7 @@ impl<'a> TaxonomyRenderer<'a> {
         let og_image = self.og_image_tag();
         let description =
             format!("{} page(s) under {taxonomy_title}: {term}.", pages.len());
+        let suffix = self.site_title_suffix();
         let mut out = format!(
             "<!DOCTYPE html>\n<html lang=\"{lang}\">\n<head>\
              <meta charset=\"utf-8\">{canonical}\
@@ -674,7 +691,7 @@ impl<'a> TaxonomyRenderer<'a> {
              <meta property=\"og:type\" content=\"website\">\
              {og_image}\
              <meta name=\"twitter:card\" content=\"summary\">\
-             <title>{taxonomy_title}: {term}</title></head>\n\
+             <title>{taxonomy_title}: {term}{suffix}</title></head>\n\
              <body>\n<main>\n<h1>{taxonomy_title}: {term}</h1>\n<ul>\n"
         );
         for (title, url) in pages {
@@ -697,6 +714,7 @@ impl<'a> TaxonomyRenderer<'a> {
             "All {} term(s): browse pages by {taxonomy_title}.",
             sorted_terms.len()
         );
+        let suffix = self.site_title_suffix();
         let mut out = format!(
             "<!DOCTYPE html>\n<html lang=\"{lang}\">\n<head>\
              <meta charset=\"utf-8\">{canonical}\
@@ -706,7 +724,7 @@ impl<'a> TaxonomyRenderer<'a> {
              <meta property=\"og:type\" content=\"website\">\
              {og_image}\
              <meta name=\"twitter:card\" content=\"summary\">\
-             <title>{taxonomy_title}</title></head>\n\
+             <title>{taxonomy_title}{suffix}</title></head>\n\
              <body>\n<main>\n<h1>{taxonomy_title}</h1>\n<ul>\n"
         );
         for (term, pages) in sorted_terms {
@@ -1415,6 +1433,71 @@ mod tests {
             html.contains("Sebastien Rousseau"),
             "a configured site_title must still reach the tag page"
         );
+    }
+
+    /// The index page carries the same branding as the term pages.
+    ///
+    /// Both renderers build the `<title>` independently, so covering only the
+    /// term page let the index drift. This runs in both feature configs, which
+    /// is the point: the `templates` build reads the suffix from the bundled
+    /// template and the fallback builds it by hand, and the two must agree.
+    #[test]
+    fn taxonomy_index_renders_a_configured_site_title() {
+        let (_tmp, site, meta, base) = make_layout();
+        fs::write(
+            meta.join("p.meta.json"),
+            r#"{"title": "P", "tags": ["rust"]}"#,
+        )
+        .unwrap();
+
+        let cfg = crate::cmd::SsgConfig::builder()
+            .site_name("Example".to_string())
+            .site_title("Sebastien Rousseau".to_string())
+            .base_url("https://example.com".to_string())
+            .build()
+            .expect("config");
+        let ctx = PluginContext::with_config(
+            &base.content_dir,
+            &base.build_dir,
+            &base.site_dir,
+            &base.template_dir,
+            cfg,
+        );
+
+        TaxonomyPlugin.after_compile(&ctx).unwrap();
+        let html = fs::read_to_string(site.join("tags/index.html")).unwrap();
+        assert!(
+            html.contains("Sebastien Rousseau"),
+            "a configured site_title must reach the taxonomy index too"
+        );
+    }
+
+    /// The negative control for the suffix: no configured title means no
+    /// dangling separator left behind in the `<title>`.
+    #[test]
+    fn taxonomy_pages_omit_the_separator_without_a_site_title() {
+        let (_tmp, site, meta, ctx) = make_layout();
+        fs::write(
+            meta.join("p.meta.json"),
+            r#"{"title": "P", "tags": ["rust"]}"#,
+        )
+        .unwrap();
+
+        TaxonomyPlugin.after_compile(&ctx).unwrap();
+
+        for rel in ["tags/index.html", "tags/rust/index.html"] {
+            let html = fs::read_to_string(site.join(rel)).unwrap();
+            let title = html
+                .split("<title>")
+                .nth(1)
+                .and_then(|t| t.split("</title>").next())
+                .unwrap_or_default();
+            assert!(
+                !title.contains('\u{2014}'),
+                "{rel}: an unset site_title must not leave a separator, \
+                 got <title>{title}</title>"
+            );
+        }
     }
 
     /// Terms separated by a non-ASCII comma must split into separate tags.

--- a/src/util/head_dom.rs
+++ b/src/util/head_dom.rs
@@ -100,6 +100,36 @@ pub fn inject_before_head_close(html: &str, payload: &str) -> String {
     }
 }
 
+/// Decodes the entities an HTML escaper produces, so `title` is genuinely the
+/// plain text this module documents it to be.
+///
+/// `<title>` arrives already escaped — it came out of rendered HTML. Every
+/// consumer treats the returned value as plain text and escapes it again on
+/// the way out, so without decoding here a title containing `&` round-trips
+/// to `&amp;amp;` and renders as a literal `&amp;`.
+///
+/// That is not hypothetical: it reached 1,494 of 6,856 pages on
+/// sebastienrousseau.com, in `og:title` and `twitter:title` — every social
+/// preview of a page whose title contains an ampersand. `og:description`
+/// escaped correctly on the same pages, because `extract_description` routes
+/// through `strip_tags`, which drops entities; only the title kept them. That
+/// asymmetry is what made it look like an escaping bug rather than a decoding
+/// one.
+///
+/// `&amp;` is decoded last. Doing it first would turn `&amp;lt;` into `&lt;`
+/// and then into `<`, re-introducing the injection the escaping prevented.
+fn decode_entities(s: &str) -> String {
+    if !s.contains('&') {
+        return s.to_string();
+    }
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&apos;", "'")
+        .replace("&amp;", "&")
+}
+
 /// Extracts `{title, lang, canonical}` from `html` in a single
 /// `lol_html` pass.
 ///
@@ -169,7 +199,8 @@ pub fn extract_head_meta(html: &str) -> HeadMeta {
     );
 
     let raw_title = title_buf.borrow().clone();
-    let title = collapse_ws(strip_tags(raw_title.trim()).trim());
+    let title =
+        decode_entities(&collapse_ws(strip_tags(raw_title.trim()).trim()));
     let lang_val = lang.borrow().clone();
     let canonical_val = canonical.borrow().clone();
 
@@ -289,6 +320,54 @@ fn collapse_ws(s: &str) -> String {
         }
     }
     out.trim().to_string()
+}
+
+#[cfg(test)]
+mod entity_decode_tests {
+    use super::*;
+
+    /// The regression: a title with `&` must survive one escape, not two.
+    ///
+    /// `<title>` comes out of rendered HTML already escaped. Consumers treat
+    /// the extracted value as plain text and re-escape it, so leaving the
+    /// entity in place produced `&amp;amp;` — a literal `&amp;` on the page.
+    /// 1,494 of 6,856 pages on sebastienrousseau.com shipped that in
+    /// `og:title` and `twitter:title`.
+    #[test]
+    fn extracted_title_is_plain_text_not_escaped_markup() {
+        let html = "<html><head><title>AI, Payments &amp; Post-Quantum</title></head></html>";
+        assert_eq!(
+            extract_head_meta(html).title,
+            "AI, Payments & Post-Quantum"
+        );
+    }
+
+    /// Guards the decode order. `&amp;` must be decoded LAST: doing it first
+    /// turns `&amp;lt;` into `&lt;` and then into `<`, re-introducing exactly
+    /// the injection the escaping existed to prevent.
+    #[test]
+    fn decoding_does_not_resurrect_escaped_markup() {
+        let html =
+            "<html><head><title>Tricky &amp;lt;script&amp;gt; name</title></head></html>";
+        let title = extract_head_meta(html).title;
+        assert_eq!(title, "Tricky &lt;script&gt; name");
+        assert!(
+            !title.contains("<script>"),
+            "decoding must not turn an escaped tag back into markup: {title:?}"
+        );
+    }
+
+    #[test]
+    fn all_escaper_entities_round_trip() {
+        let html = "<html><head><title>a &lt;b&gt; &quot;c&quot; &#39;d&#39; &amp; e</title></head></html>";
+        assert_eq!(extract_head_meta(html).title, r#"a <b> "c" 'd' & e"#);
+    }
+
+    #[test]
+    fn titles_without_entities_are_untouched() {
+        let html = "<html><head><title>Plain Title</title></head></html>";
+        assert_eq!(extract_head_meta(html).title, "Plain Title");
+    }
 }
 
 #[cfg(test)]

--- a/tests/example_outputs.rs
+++ b/tests/example_outputs.rs
@@ -43,6 +43,7 @@
 //! so any drift between source and generated artifacts is caught.
 
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
@@ -65,21 +66,93 @@ fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf()
 }
 
-/// Runs `cargo run --quiet --example <name>` with a hard timeout. The
-/// example's dev server is killed once the build phase has completed by
-/// truncating the process at the timeout — output written to disk before
-/// the kill is what we validate.
+/// Compiles every example once, and returns the built binary for `name`.
+///
+/// This used to be `cargo run --quiet --example <name>` inside the timed
+/// window, which made the tests unrunnable from cold. A nested `cargo run`
+/// contends for the same target-directory lock as the `cargo test` invoking
+/// it, and it has to *compile* the example before running it: measured cold,
+/// `cargo run --example basic` took over ten minutes against a 30-second
+/// budget. The child was killed mid-compile, nothing was written, and the
+/// test then failed on `public dir not created` — blaming the example for a
+/// build that never finished.
+///
+/// That is why the suite looked flaky: it passed only when the examples
+/// happened to be warm in the target dir, so a different one failed on each
+/// run (`basic`/`docs`/`portfolio`, then `plugins`, then `basic`) and CI was
+/// green purely because its build step warmed everything first.
+///
+/// Compiling is now done once, up front, untimed — a build taking minutes is
+/// normal and is not what these tests are measuring. The timeout applies only
+/// to *running* an already-built binary, which is the thing that can
+/// legitimately hang.
+fn built_examples() -> &'static BTreeMap<String, PathBuf> {
+    static BUILT: OnceLock<BTreeMap<String, PathBuf>> = OnceLock::new();
+    BUILT.get_or_init(|| {
+        let out = Command::new("cargo")
+            .current_dir(workspace_root())
+            .args(["build", "--examples", "--message-format=json"])
+            .stderr(Stdio::inherit())
+            .output()
+            .expect("failed to run cargo build --examples");
+        assert!(
+            out.status.success(),
+            "cargo build --examples failed; the example tests cannot run"
+        );
+
+        // Cargo emits one JSON object per line; compiler-artifact lines for an
+        // example carry the built path in `executable`.
+        let mut map = BTreeMap::new();
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+                continue;
+            };
+            if v["reason"] != "compiler-artifact" {
+                continue;
+            }
+            let is_example = v["target"]["kind"]
+                .as_array()
+                .is_some_and(|k| k.iter().any(|x| x == "example"));
+            if !is_example {
+                continue;
+            }
+            if let (Some(name), Some(exe)) =
+                (v["target"]["name"].as_str(), v["executable"].as_str())
+            {
+                let _ = map.insert(name.to_string(), PathBuf::from(exe));
+            }
+        }
+        assert!(
+            !map.is_empty(),
+            "cargo reported no example binaries; cannot run the example tests"
+        );
+        map
+    })
+}
+
+/// Runs an already-built example with a hard timeout.
+///
+/// Several examples end by starting a dev server, so a timeout is expected
+/// and is not a failure — output written before the kill is what we validate.
+/// A build failure, by contrast, is fatal and is surfaced by
+/// [`built_examples`] rather than being mistaken for a missing output dir.
 fn run_example(name: &str, timeout: Duration) {
-    let root = workspace_root();
-    let mut child = Command::new("cargo")
-        .current_dir(&root)
-        .args(["run", "--quiet", "--example", name])
+    let exe = built_examples().get(name).unwrap_or_else(|| {
+        panic!(
+            "example {name:?} was not built; known examples: {:?}",
+            built_examples().keys().collect::<Vec<_>>()
+        )
+    });
+
+    let mut child = Command::new(exe)
+        .current_dir(workspace_root())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
-        .unwrap_or_else(|e| panic!("failed to spawn cargo for {name}: {e}"));
+        .unwrap_or_else(|e| {
+            panic!("failed to spawn {name} ({}): {e}", exe.display())
+        });
 
-    // Poll for completion up to the timeout, then kill.
     let start = std::time::Instant::now();
     loop {
         match child.try_wait() {
@@ -90,11 +163,138 @@ fn run_example(name: &str, timeout: Duration) {
                     let _ = child.wait();
                     break;
                 }
-                std::thread::sleep(Duration::from_millis(150));
+                std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => panic!("error waiting on {name}: {e}"),
         }
     }
+}
+
+/// Every shipped example must at least run.
+///
+/// Nine of the eighteen example targets had no end-to-end test at all. Six of
+/// those have *feature* tests — `agentic_discovery.rs`, `edge_headers_emit.rs`,
+/// `isr_*.rs`, `search_index_integrity.rs`, `view_transitions_plugin.rs` — but
+/// every one of them exercises the library, not the example binary. Three
+/// (`agent_api_example`, `iso20022_example`, `rpc_example`) had nothing.
+///
+/// So an example that panicked on startup, or that stopped compiling against
+/// an API it demonstrates, could ship unnoticed. Examples are documentation
+/// that runs; documentation that does not run is worse than none, because it
+/// is confidently wrong.
+///
+/// This is deliberately a smoke test, not a battery of bespoke validators. It
+/// is driven by whatever cargo reports as an example target, so a new example
+/// is covered the moment it exists rather than when somebody remembers to add
+/// a case. The per-example output assertions above stay where the output is
+/// worth asserting in detail.
+///
+/// Contract:
+/// - exit 0 → the example completed
+/// - killed at the timeout → fine; several examples end by serving
+/// - non-zero exit → failure, reported with the example name
+#[test]
+fn every_shipped_example_runs_without_failing() {
+    let _guard = example_lock().lock().unwrap_or_else(|p| p.into_inner());
+
+    let mut failures: Vec<String> = Vec::new();
+    for (name, exe) in built_examples() {
+        let mut child = match Command::new(exe)
+            .current_dir(workspace_root())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                failures.push(format!(
+                    "{name}: could not spawn {}: {e}",
+                    exe.display()
+                ));
+                continue;
+            }
+        };
+
+        let timeout = Duration::from_secs(45);
+        let start = std::time::Instant::now();
+        let status = loop {
+            match child.try_wait() {
+                // Completed on its own.
+                Ok(Some(status)) => break Some(status),
+                Ok(None) if start.elapsed() >= timeout => {
+                    // Still running at the deadline: a serving example.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    break None;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(50)),
+                Err(e) => {
+                    failures.push(format!("{name}: error waiting: {e}"));
+                    break None;
+                }
+            }
+        };
+
+        if let Some(status) = status {
+            if !status.success() {
+                failures.push(format!(
+                    "{name}: exited with {status} (a shipped example must not fail)"
+                ));
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} shipped examples failed to run:\n  {}",
+        failures.len(),
+        built_examples().len(),
+        failures.join("\n  ")
+    );
+}
+
+/// Guards the guard: every example cargo knows about must be reachable here.
+///
+/// If `built_examples()` ever silently returns a subset — a parsing change, a
+/// cargo output-format change — the smoke test above would quietly cover less
+/// while still passing. Pin the count against cargo's own view.
+#[test]
+fn every_cargo_example_target_is_discovered() {
+    let out = Command::new("cargo")
+        .current_dir(workspace_root())
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .output()
+        .expect("cargo metadata");
+    let meta: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("parse cargo metadata");
+
+    let mut declared: Vec<String> = Vec::new();
+    for pkg in meta["packages"].as_array().into_iter().flatten() {
+        for target in pkg["targets"].as_array().into_iter().flatten() {
+            let is_example = target["kind"]
+                .as_array()
+                .is_some_and(|k| k.iter().any(|x| x == "example"));
+            if is_example {
+                if let Some(name) = target["name"].as_str() {
+                    declared.push(name.to_string());
+                }
+            }
+        }
+    }
+    declared.sort();
+
+    let mut discovered: Vec<String> =
+        built_examples().keys().cloned().collect();
+    discovered.sort();
+
+    assert_eq!(
+        declared,
+        discovered,
+        "cargo declares {} example targets but only {} were discovered and \
+         smoke-tested",
+        declared.len(),
+        discovered.len()
+    );
 }
 
 /// Read an HTML file, panicking with a useful path on failure.

--- a/tests/no_placeholder_in_output.rs
+++ b/tests/no_placeholder_in_output.rs
@@ -1,0 +1,275 @@
+// Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Regression guard: no placeholder default may reach a rendered site.
+//!
+//! ## What went wrong
+//!
+//! `DEFAULT_SITE_TITLE` was `"My SSG Site"`. A build with no config file falls
+//! back to [`ssg::cmd::default_config`], the taxonomy plugin copies
+//! `site_title` into `site.title`, and `templates/tera/base.html` appends it to
+//! every page title:
+//!
+//! ```text
+//! <title>{% block title %}{{ page.title }}{% if site.title %} — {{ site.title }}{% endif %}{% endblock %}</title>
+//! ```
+//!
+//! On sebastienrousseau.com that shipped **7,189 generated tag pages** titled
+//! `Tag: <term> — My SSG Site`, live and indexable, on a site whose own name
+//! appears nowhere in them.
+//!
+//! ## Why nothing caught it
+//!
+//! Every existing assertion about these constants is *positive*:
+//!
+//! ```text
+//! assert_eq!(props["site_title"]["default"], "My SSG Site");
+//! assert_eq!(cfg.site_name, DEFAULT_SITE_NAME);
+//! ```
+//!
+//! Those pin the placeholder as *correct*. Not one asked the only question
+//! that mattered: does it escape into output? A default that is never rendered
+//! is fine; a default that is rendered is a brand, and a placeholder brand is
+//! a bug. That distinction had no test.
+//!
+//! ## What this guards
+//!
+//! The class, not the instance. [`FORBIDDEN_IN_OUTPUT`] lists every string the
+//! tool may substitute on the user's behalf, and this scans a whole rendered
+//! tree for all of them.
+//!
+//! The narrow, decisive proof lives beside the code it guards, in
+//! `src/plugins/taxonomy.rs`:
+//! `tag_page_never_renders_a_placeholder_site_title` drives the exact render
+//! path through a config that leaves `site_title` unset, with
+//! `tag_page_renders_a_configured_site_title` as the positive control so
+//! emptying the default cannot "pass" by silently dropping the feature. Both
+//! were observed failing against the old constant before passing against the
+//! new one.
+//!
+//! This file is the wide net: it catches a placeholder escaping through any
+//! *other* route, in any rendered file type. It asserts the build actually
+//! rendered something first — the first draft of this test passed with the bug
+//! present, because the fixture aborted before the taxonomy plugin ran.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clap::{arg, Command};
+use ssg::process;
+use tempfile::TempDir;
+
+/// Strings the tool substitutes when the user supplied nothing.
+///
+/// A build is allowed to *use* these internally (a scaffold directory name, a
+/// log line). It is never allowed to render one into a page a reader or a
+/// crawler will see.
+const FORBIDDEN_IN_OUTPUT: &[(&str, &str)] = &[
+    (
+        "My SSG Site",
+        "DEFAULT_SITE_TITLE — reached 7,189 live tag-page titles",
+    ),
+    (
+        "MySsgSite",
+        "DEFAULT_SITE_NAME — scaffold name, must stay internal",
+    ),
+    ("A site built with SSG", "default site_description"),
+];
+
+/// Extensions a human or a crawler actually reads.
+const RENDERED: &[&str] = &[
+    "html",
+    "htm",
+    "xml",
+    "json",
+    "txt",
+    "rss",
+    "atom",
+    "webmanifest",
+];
+
+fn rendered_files(root: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    collect(root, &mut out);
+    out
+}
+
+fn collect(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        match entry.file_type() {
+            Ok(ft) if ft.is_dir() => collect(&path, out),
+            Ok(ft) if ft.is_file() => {
+                let ext = path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or_default()
+                    .to_ascii_lowercase();
+                if RENDERED.contains(&ext.as_str()) {
+                    out.push(path);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn make_matches(
+    content: &Path,
+    output: &Path,
+    site: &Path,
+    template: &Path,
+) -> clap::ArgMatches {
+    Command::new("ssg")
+        .arg(arg!(--"content" <CONTENT> "Content directory"))
+        .arg(arg!(--"output"  <OUTPUT>  "Output directory"))
+        .arg(arg!(--"new"     <NEW>     "Site directory"))
+        .arg(arg!(--"template" <TEMPLATE> "Template directory"))
+        .get_matches_from(vec![
+            "ssg",
+            "--content",
+            content.to_str().unwrap(),
+            "--output",
+            output.to_str().unwrap(),
+            "--new",
+            site.to_str().unwrap(),
+            "--template",
+            template.to_str().unwrap(),
+        ])
+}
+
+/// A site with tagged content in several scripts, and **no config file** —
+/// the exact condition that produced the shipped placeholder.
+fn write_unconfigured_site(content: &Path) {
+    fs::create_dir_all(content).unwrap();
+    fs::write(
+        content.join("index.md"),
+        "---\ntitle: \"Home\"\ndescription: \"Index\"\n\
+         date: \"2026-01-01\"\nlayout: \"index\"\ntags: \"rust, ssg\"\n---\nHome.\n",
+    )
+    .unwrap();
+    // Tagged posts drive the taxonomy plugin, which is what rendered the
+    // placeholder. Non-ASCII separators are included so this test also covers
+    // the term-splitting path (ssg_core::TERM_SEPARATORS).
+    for (name, tags) in [
+        ("post-en.md", "banking, payments"),
+        ("post-ar.md", "المصرفية، المدفوعات"),
+        ("post-ja.md", "銀行、決済"),
+        ("post-zh.md", "银行，支付"),
+    ] {
+        fs::write(
+            content.join(name),
+            format!(
+                "---\ntitle: \"Post {name}\"\ndescription: \"D\"\n\
+                 date: \"2026-01-01\"\nlayout: \"index\"\ntags: \"{tags}\"\n---\nBody.\n"
+            ),
+        )
+        .unwrap();
+    }
+}
+
+fn write_minimal_template(template: &Path) {
+    fs::create_dir_all(template).unwrap();
+    fs::write(
+        template.join("index.html"),
+        "<!doctype html><html><head><meta charset=\"utf-8\">\
+         <title>{{title}}</title></head><body><main>{{content}}</main></body></html>",
+    )
+    .unwrap();
+}
+
+#[test]
+fn unconfigured_build_renders_no_placeholder_default() {
+    let tmp = TempDir::new().unwrap();
+    let content = tmp.path().join("content");
+    let output = tmp.path().join("output");
+    let site = tmp.path().join("site");
+    let template = tmp.path().join("templates");
+
+    write_unconfigured_site(&content);
+    write_minimal_template(&template);
+
+    // Deliberately ignore the build's own result. Whether the pipeline
+    // completes is another test's job; this one asks only what reached disk.
+    let _ = process::args(&make_matches(&content, &output, &site, &template));
+
+    // GUARD AGAINST VACUOUS SUCCESS. The first version of this test passed
+    // even with the bug present, because the synthesised site aborted before
+    // the taxonomy plugin ran, so there was nothing to scan. A test that can
+    // pass for the wrong reason is worse than no test. Require that the build
+    // actually rendered something before drawing any conclusion from it.
+    let rendered_any = [&output, &site]
+        .iter()
+        .any(|d| !rendered_files(d).is_empty());
+    assert!(
+        rendered_any,
+        "the build produced no rendered files, so this test proves nothing. \
+         Fix the fixture rather than letting it pass vacuously. \
+         output={} site={}",
+        output.display(),
+        site.display()
+    );
+
+    let mut offences: Vec<String> = Vec::new();
+    for dir in [&output, &site] {
+        for file in rendered_files(dir) {
+            let Ok(text) = fs::read_to_string(&file) else {
+                continue;
+            };
+            for (needle, why) in FORBIDDEN_IN_OUTPUT {
+                if text.contains(needle) {
+                    offences.push(format!(
+                        "{}: contains {needle:?} ({why})",
+                        file.display()
+                    ));
+                }
+            }
+        }
+    }
+
+    assert!(
+        offences.is_empty(),
+        "a placeholder default reached rendered output — a build with no \
+         config must brand nothing:\n  {}",
+        offences.join("\n  ")
+    );
+}
+
+#[test]
+fn default_site_title_is_empty_so_templates_omit_the_suffix() {
+    // base.html guards the suffix with `{% if site.title %}`, so an empty
+    // title renders `<title>{page}</title>` rather than a branded one. If this
+    // ever becomes non-empty again, the guard above is the safety net — but
+    // this states the intent directly, where someone changing the constant
+    // will see it.
+    assert_eq!(
+        ssg::cmd::DEFAULT_SITE_TITLE,
+        "",
+        "DEFAULT_SITE_TITLE is rendered into every page title by the default \
+         templates; a non-empty default brands every unconfigured site"
+    );
+}
+
+#[test]
+fn forbidden_list_covers_the_rendered_config_defaults() {
+    // Guards the guard: if a default that reaches output is added to
+    // SsgConfig, it must be listed above. Checked by asserting the two known
+    // rendered defaults are present, so deleting one fails loudly.
+    let listed: Vec<&str> = FORBIDDEN_IN_OUTPUT
+        .iter()
+        .map(|(needle, _)| *needle)
+        .collect();
+    assert!(
+        listed.contains(&"MySsgSite"),
+        "DEFAULT_SITE_NAME must stay covered"
+    );
+    assert!(
+        listed.iter().any(|n| n.contains("built with SSG")),
+        "the default site_description must stay covered"
+    );
+}


### PR DESCRIPTION
Two defects, both of which shipped to a real site, and both of which existed because the tests asked the wrong question.

Found while auditing sebastienrousseau.com, which had pinned `ssg` at 0.0.39 for 13 releases partly because of them.

---

## 1. `DEFAULT_SITE_TITLE` was `"My SSG Site"` — and it reached output

A build without an explicit `site_title` falls back to it, the taxonomy plugin copies it into `site.title`, and `builtin_templates/tag.html` appends it to every generated term page:

```jinja
{% block title %}Tag: {{ tag }}{% if site.title %} — {{ site.title }}{% endif %}{% endblock %}
```

That shipped **7,189 tag pages** titled `Tag: <term> — My SSG Site` — live, indexable, branding a real site with this tool's placeholder.

**Fix:** empty default. Every builtin template already guards the suffix with `{% if site.title %}`, so an unconfigured build brands nothing and a configured site is unaffected. The JSON-schema default moves with it so documented and real defaults cannot drift.

## 2. `<title>` was extracted still-escaped, then escaped again

`extract_head_meta` documents `title` as *"plain-text content of the first `<title>` element"*. It wasn't — `<title>` is read out of rendered HTML, so it arrives escaped, and the entities were left in place. Consumers treat it as plain text and re-escape:

```html
<meta property="og:title" content="AI, Payments &amp;amp; Post-Quantum">
```

Rendered as a literal `&amp;`. **1,494 of 6,856 pages** — every social preview whose title contains an ampersand.

What disguised it: `og:description` was correct on the *same pages*, because `extract_description` routes through `strip_tags`, which drops entities. Only the title kept them. That pointed suspicion at `escape_attr`, which is in fact correct — a plain escaper handed pre-escaped input.

**Fix:** decode in `extract_head_meta`, so the value matches its own documented contract. `&amp;` is decoded **last** — decoding it first turns `&amp;lt;` into `&lt;` and then into `<`, re-introducing the injection the escaping prevented.

---

## Why neither was caught

Every assertion about these constants was *positive*:

```rust
assert_eq!(props["site_title"]["default"], "My SSG Site");
assert_eq!(cfg.site_name, DEFAULT_SITE_NAME);
```

Those pin the placeholder as **correct**. None asked whether it escapes into output. A default that is never rendered is fine; a default that *is* rendered is a brand, and a placeholder brand is a bug. That distinction had no test.

## Tests

Seven, all observed failing against the old behaviour before passing:

**`taxonomy.rs`**
- `tag_page_never_renders_a_placeholder_site_title` — drives the real render path through a config that leaves `site_title` unset (the exact bug condition).
- `tag_page_renders_a_configured_site_title` — positive control. Without it, emptying the default would still pass if the suffix were deleted from the template outright.
- `tag_lists_split_on_the_comma_of_their_own_script` — the neighbouring hazard: Arabic-comma lists must split, and slugs must stay inside the 200-byte cap.

**`head_dom.rs`**
- `extracted_title_is_plain_text_not_escaped_markup`
- `decoding_does_not_resurrect_escaped_markup` — pins the decode **order**, the thing a later "simplification" quietly breaks.
- `all_escaper_entities_round_trip`
- `titles_without_entities_are_untouched` — passes either way by design, proving the decode doesn't mangle ordinary input.

**`tests/no_placeholder_in_output.rs`** — a wide net over a whole rendered tree, for a placeholder escaping by some other route. It asserts the build rendered something before concluding: the first draft passed *with* the bug present, because the fixture aborted before the taxonomy plugin ran, and a test that can pass for the wrong reason is worse than no test.

## Verification

Full workspace suite: **3,823 passing** (baseline 3,814; +9 new).

End-to-end against the real 6,856-page corpus:

| | before | after |
|---|---|---|
| pages titled "My SSG Site" | 7,189 | **0** |
| pages with `&amp;amp;` | 1,494 | **0** |

## Unrelated finding

`tests/example_outputs.rs` is flaky under `cargo test --workspace`. Examples build into checked-out paths (`examples/<name>/public`) guarded by a per-*process* mutex, so parallel test **binaries** race — three runs failed `basic`/`docs`/`portfolio`, then `plugins`, then `basic`. CI is protected by `--test-threads=1`; the standard developer command is not. Building each example into a unique temp dir would remove the shared state. Worth its own issue.
