### PR TITLE
fix(search): fetch the index from the site, not the host root

### DIFF
--- a/crates/ssg-a11y/src/html.rs
+++ b/crates/ssg-a11y/src/html.rs
@@ -44,7 +44,10 @@ pub(crate) fn is_decorative_img(tag: &str) -> bool {
 /// tag that starts at `tag_start`. Skips `>` characters that occur inside
 /// double- or single-quoted attribute values so that inline SVG `data:`
 /// URLs in `src` attributes don't truncate the tag prematurely.
-pub(crate) fn find_tag_end(html: &str, tag_start: usize) -> usize {
+// `const` because clippy::missing_const_for_fn asks for it under Rust
+// 1.98, where the lint learned to see through this loop. Nothing about
+// the body changed — it was already const-compatible.
+pub(crate) const fn find_tag_end(html: &str, tag_start: usize) -> usize {
     let bytes = html.as_bytes();
     let mut i = tag_start;
     let mut quote: Option<u8> = None;

--- a/crates/ssg-search/src/artifacts.rs
+++ b/crates/ssg-search/src/artifacts.rs
@@ -460,7 +460,11 @@ fn sha256(input: &[u8]) -> [u8; 32] {
     }
     msg.extend_from_slice(&bit_len.to_be_bytes());
 
-    for block in msg.chunks_exact(64) {
+    // `as_chunks` yields `&[u8; 64]`, so the block length is a type
+    // guarantee rather than a runtime property. `.1` is the remainder,
+    // which is empty here because the message was padded to a multiple of
+    // 64 above.
+    for block in msg.as_chunks::<64>().0 {
         let mut w = [0u32; 64];
         for i in 0..16 {
             w[i] = u32::from_be_bytes([

--- a/crates/ssg-search/src/engine.rs
+++ b/crates/ssg-search/src/engine.rs
@@ -169,11 +169,13 @@ impl VectorEngine {
         // little + 4-byte alignment guarantees we can't make from
         // arbitrary slices.)
         let mut corpus = Vec::with_capacity(count * dim);
-        for chunk in embeddings_bytes.chunks_exact(4) {
-            // chunk is always length 4 here because of chunks_exact.
-            corpus.push(f32::from_le_bytes([
-                chunk[0], chunk[1], chunk[2], chunk[3],
-            ]));
+        // `as_chunks` yields `&[u8; 4]` rather than a slice that merely
+        // happens to be four long, so the array is passed straight to
+        // `from_le_bytes` with no indexing and no length assumption to
+        // comment on. `.1` is the remainder, which a well-formed
+        // embeddings blob does not have.
+        for chunk in embeddings_bytes.as_chunks::<4>().0 {
+            corpus.push(f32::from_le_bytes(*chunk));
         }
         Ok(Self {
             encoder,

--- a/examples/search_example.rs
+++ b/examples/search_example.rs
@@ -76,7 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let query = "sepa iban payment";
     let hits = engine.search(query, 3);
     println!("[search] query: {query:?} → {} hits", hits.len() / 2);
-    for pair in hits.chunks_exact(2) {
+    for pair in hits.as_chunks::<2>().0 {
         let idx = pair[0] as usize;
         let score = pair[1];
         let entry = &arts.manifest.entries[idx];

--- a/src/audit/gates/html5.rs
+++ b/src/audit/gates/html5.rs
@@ -103,7 +103,7 @@ impl AuditGate for Html5Gate {
             }
 
             if let Some(start) = lower.find("<title") {
-                let close = lower[start..].find("</title>").map_or(0, |i| i);
+                let close = lower[start..].find("</title>").unwrap_or(0);
                 if close == 0 {
                     findings.push(
                         Finding::new(

--- a/src/audit/gates/util.rs
+++ b/src/audit/gates/util.rs
@@ -20,7 +20,7 @@
 /// assert_eq!(find_tag_end(html, 0), 4);
 /// ```
 #[allow(dead_code)]
-pub fn find_tag_end(html: &str, tag_start: usize) -> usize {
+pub const fn find_tag_end(html: &str, tag_start: usize) -> usize {
     let bytes = html.as_bytes();
     let mut i = tag_start;
     let mut quote: Option<u8> = None;

--- a/src/audit/gates/wcag.rs
+++ b/src/audit/gates/wcag.rs
@@ -199,7 +199,7 @@ fn check_aria_landmarks(html: &str, out: &mut Vec<Issue>) {
     }
 }
 
-fn find_tag_end(html: &str, tag_start: usize) -> usize {
+const fn find_tag_end(html: &str, tag_start: usize) -> usize {
     let bytes = html.as_bytes();
     let mut i = tag_start;
     let mut quote: Option<u8> = None;

--- a/src/core/content_stager.rs
+++ b/src/core/content_stager.rs
@@ -627,7 +627,7 @@ fn extract_simple_vars(
     }
 }
 
-fn find_closing_braces(s: &str) -> Option<usize> {
+const fn find_closing_braces(s: &str) -> Option<usize> {
     let bytes = s.as_bytes();
     let mut j = 0;
     while j + 1 < bytes.len() {

--- a/src/plugins/markdown_ext.rs
+++ b/src/plugins/markdown_ext.rs
@@ -406,7 +406,7 @@ fn apply_strikethrough(line: &str) -> Cow<'_, str> {
 }
 
 /// Returns the byte offset of the next `~~` after `from`, or `None`.
-fn find_strike_close(line: &str, from: usize) -> Option<usize> {
+const fn find_strike_close(line: &str, from: usize) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut j = from;
     while j + 1 < bytes.len() {

--- a/src/plugins/search.rs
+++ b/src/plugins/search.rs
@@ -378,9 +378,13 @@ impl Plugin for SearchPlugin {
         &self,
         html: &str,
         _path: &Path,
-        _ctx: &PluginContext,
+        ctx: &PluginContext,
     ) -> Result<String, SsgError> {
-        transform_search_html(html, &SearchLabels::english())
+        transform_search_html(
+            html,
+            &SearchLabels::english(),
+            &site_path_prefix(ctx),
+        )
     }
 
     fn after_compile(&self, ctx: &PluginContext) -> Result<(), SsgError> {
@@ -436,9 +440,9 @@ impl Plugin for LocalizedSearchPlugin {
         &self,
         html: &str,
         _path: &Path,
-        _ctx: &PluginContext,
+        ctx: &PluginContext,
     ) -> Result<String, SsgError> {
-        transform_search_html(html, &self.labels)
+        transform_search_html(html, &self.labels, &site_path_prefix(ctx))
     }
 
     fn after_compile(&self, ctx: &PluginContext) -> Result<(), SsgError> {
@@ -470,12 +474,13 @@ fn run_search_index(ctx: &PluginContext) -> Result<(), SsgError> {
 fn transform_search_html(
     html: &str,
     labels: &SearchLabels,
+    site_prefix: &str,
 ) -> Result<String, SsgError> {
     if html.contains("ssg-search-widget") {
         return Ok(html.to_string()); // Already injected
     }
 
-    let script = build_widget_script(labels);
+    let script = build_widget_script(labels, site_prefix);
 
     let injected = if let Some(pos) = html.rfind("</body>") {
         format!("{}{}{}", &html[..pos], script, &html[pos..])
@@ -656,11 +661,27 @@ fn inject_search_ui(path: &Path, script: &str) -> Result<(), SsgError> {
     Ok(())
 }
 
+/// The path component of `base_url`, or `""` when the site owns its host.
+///
+/// The widget fetches its index with a root-absolute URL. A site published
+/// under a path — `https://example.com/apex` — therefore asked for
+/// `/search-index.json` at the *host* root, which is not its own index.
+///
+/// That failed quietly in the worst way: on a host where something else
+/// answers at `/search-index.json`, search returned results from a
+/// different site rather than erroring. It only became visible when the
+/// showcase moved to a host with nothing at the root.
+fn site_path_prefix(ctx: &PluginContext) -> String {
+    ctx.config.as_ref().map_or_else(String::new, |c| {
+        crate::plugins_group::csp::base_url_path_prefix(&c.base_url)
+    })
+}
+
 /// Render [`SEARCH_WIDGET_SCRIPT`] (a template) with the given labels.
 ///
 /// HTML attribute / text values are HTML-escaped; the `no_results` string is
 /// also JS-escaped because it ends up inside a single-quoted JS string literal.
-fn build_widget_script(labels: &SearchLabels) -> String {
+fn build_widget_script(labels: &SearchLabels, site_prefix: &str) -> String {
     let no_results_with_expr = html_escape(&labels.no_results)
         .replace("{query}", "&ldquo;\'+esc(q)+\'&rdquo;");
 
@@ -680,6 +701,7 @@ fn build_widget_script(labels: &SearchLabels) -> String {
         )
         .replace("{{SSG_FOOTER_OPEN}}", &html_escape(&labels.footer_open))
         .replace("{{SSG_NO_RESULTS}}", &js_escape(&no_results_with_expr))
+        .replace("{{SSG_SITE_PREFIX}}", site_prefix)
 }
 
 /// Minimal HTML escaper covering the characters that matter inside attribute
@@ -819,7 +841,7 @@ results=document.getElementById('ssg-search-results'),
 btn=document.getElementById('ssg-search-btn'),active=-1,
 lm=location.pathname.match(/^\/(en|fr|ar|bn|cs|de|es|ha|he|hi|id|it|ja|ko|nl|pl|pt|ro|ru|sv|th|tl|tr|uk|vi|yo|zh-tw|zh)\//),
 lp=lm?'/'+lm[1]:'';
-function load(){if(idx)return Promise.resolve();var sp=lm?'/'+lm[1]+'/search-index.json':'/search-index.json';return fetch(sp).then(function(r){return r.json()}).then(function(d){idx=d.entries||[]}).catch(function(){idx=[]})}
+function load(){if(idx)return Promise.resolve();var sp=lm?'{{SSG_SITE_PREFIX}}/'+lm[1]+'/search-index.json':'{{SSG_SITE_PREFIX}}/search-index.json';return fetch(sp).then(function(r){return r.json()}).then(function(d){idx=d.entries||[]}).catch(function(){idx=[]})}
 function open(){load().then(function(){overlay.classList.add('active');input.value='';results.innerHTML='';input.focus();active=-1})}
 function close(){overlay.classList.remove('active');active=-1}
 function highlight(text,q){if(!q)return esc(text);var re=new RegExp('('+q.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')+')','gi');return esc(text).replace(re,'<mark>$1</mark>')}
@@ -857,6 +879,42 @@ mod tests {
             "<html><head><title>{title}</title></head>\
              <body><h1>{title}</h1>{body}</body></html>"
         )
+    }
+
+    /// The widget fetches its index root-absolutely, so a site published
+    /// under a path must carry that path or it asks the *host* root for an
+    /// index that is not its own.
+    ///
+    /// This failed silently rather than loudly: on a host where something
+    /// else answered at `/search-index.json`, search returned another
+    /// site's results. It only surfaced when the themes showcase moved to
+    /// a host with nothing at the root.
+    #[test]
+    fn search_index_url_carries_the_site_path_prefix() {
+        let script = build_widget_script(&SearchLabels::english(), "/apex");
+        // The non-locale branch — the one that fetched the wrong index.
+        assert!(
+            script.contains(":'/apex/search-index.json'"),
+            "default branch should be prefixed: {script}"
+        );
+        // The locale branch prefixes the locale segment, not the host root.
+        assert!(
+            script.contains("'/apex/'+lm[1]+'/search-index.json'"),
+            "locale branch should be prefixed: {script}"
+        );
+        assert!(
+            !script.contains("{{SSG_SITE_PREFIX}}"),
+            "placeholder should be substituted: {script}"
+        );
+    }
+
+    /// A site that owns its host keeps the bare path — the prefix is empty
+    /// and nothing should be doubled up.
+    #[test]
+    fn search_index_url_is_bare_without_a_prefix() {
+        let script = build_widget_script(&SearchLabels::english(), "");
+        assert!(script.contains("'/search-index.json'"), "{script}");
+        assert!(!script.contains("//search-index.json"), "{script}");
     }
 
     #[test]
@@ -1057,7 +1115,7 @@ mod tests {
         let path = tmp.path().join("page.html");
         fs::write(&path, "<html><body><p>Hello</p></body></html>").unwrap();
 
-        let script = build_widget_script(&SearchLabels::english());
+        let script = build_widget_script(&SearchLabels::english(), "");
         inject_search_ui(&path, &script).unwrap();
 
         let result = fs::read_to_string(&path).unwrap();
@@ -1073,7 +1131,7 @@ mod tests {
         let path = tmp.path().join("page.html");
         fs::write(&path, "<html><body><p>Hi</p></body></html>").unwrap();
 
-        let script = build_widget_script(&SearchLabels::english());
+        let script = build_widget_script(&SearchLabels::english(), "");
         inject_search_ui(&path, &script).unwrap();
         let first = fs::read_to_string(&path).unwrap();
 
@@ -1372,7 +1430,7 @@ mod tests {
         fs::write(&path, "<html><p>No body tag here</p></html>").unwrap();
 
         // Act
-        let script = build_widget_script(&SearchLabels::english());
+        let script = build_widget_script(&SearchLabels::english(), "");
         inject_search_ui(&path, &script).unwrap();
 
         // Assert
@@ -1655,7 +1713,7 @@ mod tests {
         let html =
             "<html><body><div id=\"ssg-search-widget\"></div></body></html>";
         let out =
-            transform_search_html(html, &SearchLabels::english()).unwrap();
+            transform_search_html(html, &SearchLabels::english(), "").unwrap();
         assert_eq!(out, html);
     }
 
@@ -1664,7 +1722,7 @@ mod tests {
         // Covers line ~448 — fallback when </body> is absent.
         let html = "<html><head></head>";
         let out =
-            transform_search_html(html, &SearchLabels::english()).unwrap();
+            transform_search_html(html, &SearchLabels::english(), "").unwrap();
         assert!(out.starts_with(html));
         assert!(out.contains("ssg-search-widget"));
     }
@@ -1869,7 +1927,7 @@ mod tests {
         fs::write(&page, "<html><body></body></html>").unwrap();
         fs::set_permissions(&page, fs::Permissions::from_mode(0o444)).unwrap();
 
-        let script = build_widget_script(&SearchLabels::english());
+        let script = build_widget_script(&SearchLabels::english(), "");
         let result = inject_search_ui(&page, &script);
         fs::set_permissions(&page, fs::Permissions::from_mode(0o644)).unwrap();
         let err =

--- a/src/plugins/seo/jsonld/mod.rs
+++ b/src/plugins/seo/jsonld/mod.rs
@@ -650,7 +650,7 @@ fn find_script_close_skipping_strings(body: &str) -> Option<usize> {
 /// Like `accessibility::find_tag_end` — returns the index just past
 /// the `>` that closes the open tag at `tag_start`, while skipping
 /// `>` characters that occur inside quoted attribute values.
-fn find_html_tag_end(html: &str, tag_start: usize) -> usize {
+const fn find_html_tag_end(html: &str, tag_start: usize) -> usize {
     let bytes = html.as_bytes();
     let mut i = tag_start;
     let mut quote: Option<u8> = None;

--- a/tests/json_feed_compliance.rs
+++ b/tests/json_feed_compliance.rs
@@ -128,7 +128,7 @@ fn ensure_blog_feed() -> PathBuf {
 }
 
 /// RFC 3339 sanity check: starts with `YYYY-MM-DDTHH:MM:SS`.
-fn looks_like_rfc3339(s: &str) -> bool {
+const fn looks_like_rfc3339(s: &str) -> bool {
     if s.len() < 19 {
         return false;
     }


### PR DESCRIPTION
The search widget fetched its index with a bare root-absolute URL,
`/search-index.json`. A site published under a path —
`https://example.com/apex` — therefore asked the **host** root for an index
that is not its own.

## It failed quietly, with plausible results

On a host where something else answers at `/search-index.json`, search
returned *that other site's* entries rather than erroring. The themes
showcase was served under `sebastienrousseau.com`, whose root does serve an
index — so every theme's search had been querying an unrelated site's
content, with no 404, no console error, and results that looked real.

It only became visible when the showcase moved to
`themes.static-site-generator.com`, a host with nothing at the root, where
the request finally 404'd.

## Fix

The widget script is already a template, so this is the same fix already
applied to `_csp/` assets, the islands loader, the SBOM link and the
taxonomy home link: substitute the path component of `base_url`.

```
apex      :'/apex/search-index.json'
atlas     :'/atlas/search-index.json'
kinetic   :'/kinetic/search-index.json'
velocity  :'/velocity/search-index.json'
```

A site that owns its host is unaffected — the prefix is empty and the URL
stays `/search-index.json`.

## Tests

Two, pinning both directions: the prefixed case asserts the default *and*
the locale branch carry the prefix and that no placeholder survives
substitution; the unprefixed case asserts the bare path with no doubled
slash.

My first version of the prefixed test was wrong — it asserted no
`'/search-index.json'` substring remained, which the locale branch
legitimately produces after concatenation (`'/apex/' + lm[1] +
'/search-index.json'`). Worth noting because the test failing was my
mistake, not the code's.

## Verification

3,578 lib tests pass · clippy clean at `-D warnings` · fmt clean · the
four-theme showcase gate green (884 responsive renders, 34 pages each
through interaction, semantics and axe, 0 defects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)