### PR TITLE
fix(seo): stop double-escaping `&` in og:title, and two siblings

### DIFF
--- a/src/plugins/og_image.rs
+++ b/src/plugins/og_image.rs
@@ -13,6 +13,7 @@ use crate::error::{PathErrorExt, SsgError};
 use crate::plugin::{Plugin, PluginContext};
 use crate::seo::helpers::{extract_title, has_meta_tag};
 use crate::util::head_dom::inject_before_head_close;
+use crate::util::html_rewriter::decode_html_entities;
 use std::{fs, path::Path};
 
 /// Plugin that auto-generates Open Graph social card images.
@@ -195,7 +196,14 @@ impl Plugin for OgImagePlugin {
                 continue;
             }
 
-            let title = extract_title(&html);
+            // `extract_title` returns the title still HTML-encoded: lol_html
+            // passes text chunks through "as-is, without unescaping", so a
+            // page titled `A & B` yields `A &amp; B`. Escaping that for SVG
+            // would emit `A &amp;amp; B` and the generated preview image
+            // would render the entity as literal text. Decode to plain text
+            // first, then let `escape_svg` do the one escape SVG needs —
+            // the same order `extract_text` already uses for the search index.
+            let title = decode_html_entities(&extract_title(&html));
             if title.is_empty() {
                 continue;
             }
@@ -307,6 +315,19 @@ mod tests {
     #[test]
     fn escape_svg_special_chars() {
         assert_eq!(escape_svg("a & b"), "a &amp; b");
+    }
+
+    /// #706 sibling: `extract_title` returns HTML-encoded text (`lol_html`
+    /// passes text chunks through without unescaping), so escaping it for
+    /// SVG without decoding first renders `&amp;` as literal text inside
+    /// the generated preview image.
+    #[test]
+    fn svg_title_round_trip_is_single_escaped() {
+        use crate::util::html_rewriter::decode_html_entities;
+        let from_page = "About: AI, Payments &amp; Post-Quantum";
+        let svg_ready = escape_svg(&decode_html_entities(from_page));
+        assert_eq!(svg_ready, "About: AI, Payments &amp; Post-Quantum");
+        assert!(!svg_ready.contains("&amp;amp;"));
         assert_eq!(escape_svg("<tag>"), "&lt;tag&gt;");
         assert_eq!(escape_svg("\"quoted\""), "&quot;quoted&quot;");
     }

--- a/src/plugins/search.rs
+++ b/src/plugins/search.rs
@@ -18,6 +18,7 @@
 
 use crate::error::{PathErrorExt, SsgError};
 use crate::plugin::{Plugin, PluginContext};
+use crate::util::html_rewriter::decode_html_entities;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -98,8 +99,15 @@ impl SearchIndex {
                         url.push(if ch == '\\' { '/' } else { ch });
                     }
 
-                    let title = extract_title(html);
-                    let headings = extract_headings(html);
+                    // `extract_text` already decodes; `extract_title` and
+                    // `extract_headings` did not, so one SearchEntry carried
+                    // plain-text content beside a title reading `A &amp; B`.
+                    // The index is consumed as text, not markup.
+                    let title = decode_html_entities(&extract_title(html));
+                    let headings = extract_headings(html)
+                        .iter()
+                        .map(|h| decode_html_entities(h))
+                        .collect();
                     let content = extract_text(html);
 
                     Ok(SearchEntry {

--- a/src/plugins/seo/helpers.rs
+++ b/src/plugins/seo/helpers.rs
@@ -140,12 +140,90 @@ pub(super) fn collect_html_files(dir: &Path) -> Result<Vec<PathBuf>, SsgError> {
     crate::walk::walk_files(dir, "html")
 }
 
+/// Longest HTML5 named reference (`CounterClockwiseContourIntegral`) is 31
+/// characters, so a well-formed `&name;` never exceeds 32 bytes past the `&`.
+const MAX_ENTITY_BYTES: usize = 32;
+
+/// If `bytes[start]` (a `&`) begins a well-formed character reference,
+/// return the index just past its `;`.
+///
+/// Accepts `&name;`, `&#NN;` and `&#xNN;`. The cap bounds the scan so a
+/// stray `&` in prose cannot walk the rest of the attribute.
+fn scan_existing_entity(bytes: &[u8], start: usize) -> Option<usize> {
+    let limit = bytes.len().min(start + MAX_ENTITY_BYTES);
+    let mut i = start + 1;
+    if i >= limit {
+        return None;
+    }
+    let numeric = bytes[i] == b'#';
+    if numeric {
+        i += 1;
+        if i < limit && (bytes[i] == b'x' || bytes[i] == b'X') {
+            i += 1;
+        }
+    }
+    let value_start = i;
+    while i < limit {
+        match bytes[i] {
+            b';' if i > value_start => return Some(i + 1),
+            b'0'..=b'9' => i += 1,
+            b'a'..=b'z' | b'A'..=b'Z' if !numeric => i += 1,
+            b'a'..=b'f' | b'A'..=b'F' if numeric => i += 1,
+            _ => return None,
+        }
+    }
+    None
+}
+
 /// Escape a string for safe inclusion in an HTML attribute value.
+///
+/// **Idempotent**: an already-formed character reference (`&amp;`, `&#39;`,
+/// `&#x27;`) is preserved verbatim rather than having its leading `&`
+/// re-escaped. This mirrors the contract `staticweaver` adopted for
+/// [ssg#589]; without it the two passes compose into `&amp;amp;`, because
+/// this function runs over values the template layer has already escaped.
+///
+/// That is not hypothetical — it shipped. `og:title` and `twitter:title` are
+/// built from already-escaped values, so a title containing `&` reached the
+/// page as `&amp;amp;` in 0.0.52 and 0.0.53 (see #706). The naive version
+/// looked correct in isolation and was covered by a test that only ever fed
+/// it raw characters.
+///
+/// [ssg#589]: https://github.com/sebastienrousseau/static-site-generator/issues/589
 pub(super) fn escape_attr(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('"', "&quot;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    let mut start = 0;
+    while i < bytes.len() {
+        let replacement = match bytes[i] {
+            b'&' => {
+                if let Some(end) = scan_existing_entity(bytes, i) {
+                    // Already a character reference — copy it through.
+                    i = end;
+                    continue;
+                }
+                "&amp;"
+            }
+            b'"' => "&quot;",
+            b'<' => "&lt;",
+            b'>' => "&gt;",
+            _ => {
+                i += 1;
+                continue;
+            }
+        };
+        if start < i {
+            out.push_str(&s[start..i]);
+        }
+        out.push_str(replacement);
+        i += 1;
+        start = i;
+    }
+    if start < s.len() {
+        out.push_str(&s[start..]);
+    }
+    out
 }
 
 /// Check for an actual `<meta` tag (not just an HTML comment marker).
@@ -486,6 +564,53 @@ mod tests {
     #[test]
     fn escape_attr_special_chars() {
         assert_eq!(escape_attr("a&b<c>d\"e"), "a&amp;b&lt;c&gt;d&quot;e");
+    }
+
+    /// #706: `og:title` / `twitter:title` are built from values the template
+    /// layer already escaped. A naive pass re-escapes the `&` of `&amp;` and
+    /// ships `&amp;amp;` to the page — 1,494 pages on one real corpus.
+    #[test]
+    fn escape_attr_preserves_existing_entities() {
+        assert_eq!(escape_attr("A &amp; B"), "A &amp; B");
+        assert_eq!(escape_attr("A &lt; B"), "A &lt; B");
+        assert_eq!(escape_attr("A &#39; B"), "A &#39; B");
+        assert_eq!(escape_attr("A &#x27; B"), "A &#x27; B");
+        assert_eq!(escape_attr("&nbsp;"), "&nbsp;");
+    }
+
+    /// The property the old test could not see, because it only ever fed
+    /// `escape_attr` raw characters: escaping twice must equal escaping once.
+    #[test]
+    fn escape_attr_is_idempotent() {
+        for input in [
+            "AI, Payments & Post-Quantum Cryptography",
+            "a&b<c>d\"e",
+            "Tom & Jerry's <b>show</b>",
+            "already &amp; escaped",
+            "mixed & already &amp; both",
+            "",
+            "no metacharacters at all",
+        ] {
+            let once = escape_attr(input);
+            let twice = escape_attr(&once);
+            assert_eq!(once, twice, "not idempotent for {input:?}");
+        }
+    }
+
+    /// A bare `&` in prose is still escaped — the entity scan must not treat
+    /// arbitrary following text as a reference, or it would silently emit
+    /// invalid markup.
+    #[test]
+    fn escape_attr_still_escapes_bare_ampersands() {
+        assert_eq!(escape_attr("Tom & Jerry"), "Tom &amp; Jerry");
+        assert_eq!(escape_attr("a & b & c"), "a &amp; b &amp; c");
+        // Unterminated / malformed references are not references.
+        assert_eq!(escape_attr("&amp"), "&amp;amp");
+        assert_eq!(escape_attr("&;"), "&amp;;");
+        assert_eq!(escape_attr("&#;"), "&amp;#;");
+        // Longer than the 32-byte cap: not a reference.
+        let long = format!("&{};", "a".repeat(40));
+        assert!(escape_attr(&long).starts_with("&amp;"));
     }
 
     #[test]

--- a/tests/example_outputs.rs
+++ b/tests/example_outputs.rs
@@ -71,6 +71,25 @@ fn workspace_root() -> PathBuf {
 /// the kill is what we validate.
 fn run_example(name: &str, timeout: Duration) {
     let root = workspace_root();
+
+    // Compile first, *untimed*. `cargo run` would otherwise make the timeout
+    // cover compilation as well as execution, and those differ by orders of
+    // magnitude: the example generates its site in ~100ms, while building it
+    // from a cold target directory takes minutes. On a cold CI cache the
+    // budget was spent before the example ever ran, and the failure surfaced
+    // as `public dir not created` — indistinguishable from a real generator
+    // bug, and not reproducible on a warm developer machine.
+    let built = Command::new("cargo")
+        .current_dir(&root)
+        .args(["build", "--quiet", "--example", name])
+        .status()
+        .unwrap_or_else(|e| {
+            panic!("failed to spawn cargo build for {name}: {e}")
+        });
+    assert!(built.success(), "{name}: example failed to compile");
+
+    // Now the timeout measures only what it claims to: how long the example
+    // takes to produce its output before its dev server blocks forever.
     let mut child = Command::new("cargo")
         .current_dir(&root)
         .args(["run", "--quiet", "--example", name])


### PR DESCRIPTION
Closes #706.

`&` in a frontmatter title reaches the page as `&amp;amp;`. On one real corpus that fails a no-double-encoding assertion on **1,494 pages**.

## The issue report was wrong twice; both are corrected here

**It is not a 0.0.52 regression.** Bisecting the published binaries against one identical input file:

| ssg | `&amp;amp;` in head |
|---|---|
| 0.0.39 | 0 |
| **0.0.46** | **2** ← first bad release |
| 0.0.49 | 2 |
| 0.0.51 | 2 |
| 0.0.52 | 2 |
| 0.0.53 | 2 |

**0.0.46 is the release that closed #589** — the same symptom.

**`staticweaver` is not at fault.** I read `0.0.5`: `escape_html_into` is entity-aware via `scan_existing_entity`, exactly as #589 required. My first hypothesis blamed it; that was wrong.

## Root cause — ours

`seo/helpers.rs::escape_attr` was naive:

```rust
s.replace('&', "&amp;").replace('"', "&quot;")…
```

and `seo_plugin.rs:184` applies it to `social.og_title`, a value the template layer has **already** escaped. Two passes compose. That is precisely why the corruption sits in `og:title`/`twitter:title` and never in body text — staticweaver handles the body correctly.

**#589 was half-fixed**: the dependency side was corrected, this call site was never touched.

## Why it survived thirteen releases

Both existing tests pass against the broken implementation, because they only ever feed raw characters:

```rust
assert_eq!(escape_attr("a&b<c>d\"e"), "a&amp;b&lt;c&gt;d&quot;e");
```

Nothing asserted `escape(escape(x)) == escape(x)`. It does now.

**Mutation-checked** — with the fix reverted:

| test | result |
|---|---|
| `escape_attr_is_idempotent` | **FAILED** |
| `escape_attr_preserves_existing_entities` | **FAILED** |
| the two pre-existing tests | passed |

## Two siblings, found by tracing the same input

lol_html passes text chunks through *"as-is, without unescaping"* (`text_chunk.rs:34`), so every consumer of `extract_title` inherits encoded text:

- **`og_image.rs`** escaped it again into the generated preview SVG — the social image rendered `&amp;` as literal text.
- **`search.rs`** decoded `content` but not `title`/`headings`, leaving one `SearchEntry` with plain-text body beside a title reading `A &amp; B`.

Both now decode before use, matching what `extract_text` already did.

## Also bundled

`tests/example_outputs.rs` compiled the example **inside** the 30-second run timeout. The example generates its site in ~100 ms; a cold build takes minutes, so CI reported `public dir not created` — indistinguishable from a generator bug, and green on any warm machine. This produced a false failure on #702. Compilation is now untimed; the timeout measures only what it claims to.

## Verification

Real corpus, the actual `about` page: **2 → 0**, matching the 0.0.39 baseline byte for byte.

| input | before | after |
|---|---|---|
| `A & B` | `A &amp;amp; B` | `A &amp; B` |
| `A &amp; B` | `A &amp;amp; B` | `A &amp; B` |
| `A &lt; B` | `A &amp;lt; B` | `A &lt; B` |
| `A < B` | `A &amp;lt; B` | `A &lt; B` |
| `Tom & Jerry's <b>` | — | `Tom &amp; Jerry&#x27;s &lt;b&gt;` |

`fmt` clean; clippy clean on both CI invocations; **3,626 tests pass** (up 4).

Warrants a 0.0.54 — every release from 0.0.46 onward corrupts these tags.