### PR TITLE
release: v0.0.54 — search fetches the index from the site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.54] - 2026-08-20
+
+Ships the search fix from #707, which landed on `main` after 0.0.53 was
+already published and so reached no release.
+
+### Fixed
+
+- **Search fetched its index from the host root, not the site** (#707).
+  The widget requested a bare `/search-index.json`, so a site published
+  under a path — `https://example.com/apex` — asked the *host* root for an
+  index that is not its own.
+
+  It failed quietly and with plausible results. On a host where something
+  else answers at `/search-index.json`, search returned that other site's
+  entries rather than erroring: no 404, no console message, results that
+  looked real. The themes showcase was served under a domain whose root
+  does serve an index, so every theme's search had been querying unrelated
+  content. It surfaced only when the showcase moved to a host with nothing
+  at the root.
+
+  The index URL now carries the path component of `base_url`, as the
+  `_csp/` assets, islands loader, SBOM link and taxonomy home link already
+  did. A site that owns its host is unaffected.
+
+- **Eight clippy findings from Rust 1.98** (#707). The runners moved to
+  1.98 and `missing_const_for_fn` (6 sites), `chunks_exact_to_as_chunks`
+  and `map_or_identity` began firing on pre-existing code. Behaviour is
+  unchanged; `as_chunks` additionally replaces a runtime length assumption
+  with a type guarantee.
+
+### Notes
+
+Anyone publishing a site under a path — a project page, or several themes
+under one domain — should take this release: on 0.0.53 and earlier their
+search either 404s or silently returns another site's results.
+
 ## [0.0.53] - 2026-08-20
 
 A one-line fix for a defect shipped in 0.0.52.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "ssg"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-a11y"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "serde",
  "serde_json",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-core"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "log",
  "noyalib 0.0.17",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "criterion",
  "inventory",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc-macro"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-search"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4942,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-wasm"
-version = "0.0.53"
+version = "0.0.54"
 dependencies = [
  "js-sys",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "ssg"                            # The name of the library
-version = "0.0.53"                      # The version of the library
+version = "0.0.54"                      # The version of the library
 authors = ["SSG Contributors"]     # The authors of the library
 edition = "2021"                        # The edition of the library
 rust-version = "1.88.0"                 # Minimum supported Rust version (set by time-macros, staticdatagen, oxc_*)
@@ -181,10 +181,10 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["html
 rayon = "1.12.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.53" }
-ssg-core = { path = "crates/ssg-core", version = "0.0.53" }
-ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.53" }
-ssg-search = { path = "crates/ssg-search", version = "0.0.53" }
+ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.54" }
+ssg-core = { path = "crates/ssg-core", version = "0.0.54" }
+ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.54" }
+ssg-search = { path = "crates/ssg-search", version = "0.0.54" }
 thiserror = "2"
 staticdatagen = "0.0.12"
 toml = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.53-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.54-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -41,7 +41,7 @@
 
 ```toml
 [dependencies]
-ssg = "0.0.53"
+ssg = "0.0.54"
 ```
 
 ### Prebuilt binaries

--- a/crates/ssg-a11y/Cargo.toml
+++ b/crates/ssg-a11y/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-a11y"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-core"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc-macro"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc/Cargo.toml
+++ b/crates/ssg-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ schemars = { version = "1.2", default-features = false, features = ["derive", "s
 thiserror = "2"
 
 # Re-export the proc-macro so users only depend on `ssg-rpc`.
-ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.53" }
+ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.54" }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/ssg-search/Cargo.toml
+++ b/crates/ssg-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-search"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-wasm/Cargo.toml
+++ b/crates/ssg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-wasm"
-version = "0.0.53"
+version = "0.0.54"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
0.0.53 was published from a commit that predates #707, so **the search fix
reached no release**. The themes showcase is currently broken in production
because of exactly this:

```
deployed widget:   :'/search-index.json'          → 404
index actually at: /kinetic/search-index.json     → 200
themes pin: ssg@0.0.51 · crates.io: 0.0.53 · fix: main only
```

## The defect

The widget requested a bare `/search-index.json`, asking the **host** root
for an index that is not the site's. A site published under a path —
`https://example.com/apex`, or several themes under one domain — never
finds its own index.

It failed quietly and with plausible results: on a host where something
else answers at `/search-index.json`, search returned *that other site's*
entries. No 404, no console message. The showcase was served under a domain
whose root does serve an index, so every theme's search had been querying
unrelated content, and it surfaced only when the showcase moved to a host
with nothing at the root.

The index URL now carries the path component of `base_url`, as the `_csp/`
assets, islands loader, SBOM link and taxonomy home link already did. A site
that owns its host is unaffected.

## Also included

The eight clippy findings from the runners' move to Rust 1.98
(`missing_const_for_fn` ×6, `chunks_exact_to_as_chunks`, `map_or_identity`).
No behaviour change; `as_chunks` additionally replaces a runtime length
assumption with a type guarantee.

## Verification

Version-coherence gate · docs_accuracy · fmt · `cargo vet --locked` · and
`cargo clippy --lib --all-features -- -D warnings` under **1.98**, the
toolchain CI now uses.

Once merged and published, the themes pin moves from 0.0.51 to 0.0.54 and
search starts working on the deployed site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)