### PR TITLE
chore(deps): build against staticdatagen 0.0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "rss-gen"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64240c5536a3e6bf8e0d760a4d555e14c95651ce26bb4d9a4210e181c1e9e04"
+checksum = "1c3b5748fb3d0f3e25d2464c3487f3dcf9add985563f082bdd18d6c1d8ed2f58"
 dependencies = [
  "log",
  "quick-xml",
@@ -4967,9 +4967,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "staticdatagen"
-version = "0.0.12"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4703ed55d7d9579e921929d3729ef0f370d4bd51d10a171bb9ab035a4bcf0e2"
+checksum = "0728f05e1dfa18a9dedfa7bd2d061e6ed36ec0442db1e2fc1cfbb3b7b2981998"
 dependencies = [
  "anyhow",
  "comrak 0.54.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ ssg-core = { path = "crates/ssg-core", version = "0.0.54" }
 ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.54" }
 ssg-search = { path = "crates/ssg-search", version = "0.0.54" }
 thiserror = "2"
-staticdatagen = "0.0.12"
+staticdatagen = "0.0.13"
 toml = "1.1.2"
 
 # Real cryptographic hashing for Subresource Integrity (issue #468 follow-up).

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -72,8 +72,8 @@ user-login = "sebastienrousseau"
 user-name = "Sebastien Rousseau"
 
 [[publisher.rss-gen]]
-version = "0.0.8"
-when = "2026-07-24"
+version = "0.0.11"
+when = "2026-08-10"
 user-id = 186843
 user-login = "sebastienrousseau"
 user-name = "Sebastien Rousseau"
@@ -86,8 +86,8 @@ user-login = "sebastienrousseau"
 user-name = "Sebastien Rousseau"
 
 [[publisher.staticdatagen]]
-version = "0.0.11"
-when = "2026-07-25"
+version = "0.0.13"
+when = "2026-08-21"
 user-id = 186843
 user-login = "sebastienrousseau"
 user-name = "Sebastien Rousseau"


### PR DESCRIPTION
Pins `staticdatagen 0.0.13`, which carries the fourth of the four fixes
0.0.55 is meant to ship. The other three are already on main (#708, #710,
#712).

## What it brings

`generate_structured_data` was enabled for every Markdown body. It reads a
`<title>`, and a Markdown body is a fragment with no `<head>` — so the step
failed on **every page ever compiled**, logging an error each time:

```
pages built:  apex 5 + atlas 10 + kinetic 5 + velocity 5 = 25
warnings:                                                  25
```

Every page failed and every page still carries a full `@graph`, which is
the proof that this path never contributed anything. Structured data comes
from the metadata plugin, which has the front matter. Output is unchanged;
25 error diagnostics per build go away.

## Why before the cut, not after

0.0.54 was published without the search fix it was named for, because the
fix landed on main after the version was already out. Tagging 0.0.55 while
this dependency still reads `0.0.12` is the same failure one layer down —
the tag would carry three of four fixes and the fourth would wait for
0.0.56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)