### PR TITLE
chore(release): 0.0.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.55] - 2026-08-21
+
+Four fixes. Three were shipping corrupted output while looking healthy.
+
+### Fixed
+
+- **`og:title` double-escaped `&` since 0.0.46** (#706, #708). `escape_attr`
+  was naive, and the SEO plugin applies it to values the template layer has
+  already escaped, so `&` reached the page as `&amp;amp;`. Bisecting the
+  published binaries against one identical input file puts the first bad
+  release at **0.0.46** — the release that *closed* #589, the same symptom.
+  That issue was only half-fixed: `staticweaver` was made entity-aware and
+  this call site was left alone, with no test asserting
+  `escape(escape(x)) == escape(x)`. There is one now. On a 34-locale corpus
+  this failed a no-double-encoding assertion on 1,494 pages.
+
+  Two siblings fell out of the same trace. `lol_html` passes text chunks
+  through "as-is, without unescaping", so everything built on
+  `extract_title` inherits encoded text: `og_image` escaped it again into
+  the generated preview SVG, and the search index decoded `content` but not
+  `title` or `headings`.
+
+- **Slug-colliding taxonomy terms overwrote each other** (#710). Terms were
+  ordered by `to_lowercase()` over a `HashMap`, a stable sort over a
+  randomised iteration order, so ties broke differently per process and the
+  build was not reproducible. Distinct spellings that slugify alike —
+  `SWIFT`/`Swift`, `CBPR`/`CBPR+` — rendered to one path and the survivor
+  was a coin flip, silently dropping the other spelling's pages. Measured on
+  a real corpus: 595 colliding slugs, 340 lowercase ties.
+
+- **Search results linked to the host root** (#712). 0.0.54 fixed loading
+  the index; it did not fix where a result sends you. `lp` was hardcoded to
+  `/`, so on a site served under a path prefix every result 404'd — while
+  the widget looked entirely healthy, which is why it went unnoticed.
+
+- **Structured data was requested from a fragment** (staticdatagen 0.0.13).
+  The step ran against the Markdown body, which has no `<head>` and so can
+  never carry a `<title>`; it failed on every page ever compiled and logged
+  at Error each time. Structured data is generated downstream from front
+  matter, where the values are actually known.
+
+### Changed
+
+- `tests/example_outputs.rs` compiles each example *outside* its 30-second
+  timeout. The budget previously had to cover compilation — ~100ms of work
+  behind a multi-minute cold build — so CI reported `public dir not created`,
+  indistinguishable from a generator bug and green on any warm machine.
+
 ## [0.0.54] - 2026-08-20
 
 Ships the search fix from #707, which landed on `main` after 0.0.53 was

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "rss-gen"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64240c5536a3e6bf8e0d760a4d555e14c95651ce26bb4d9a4210e181c1e9e04"
+checksum = "1c3b5748fb3d0f3e25d2464c3487f3dcf9add985563f082bdd18d6c1d8ed2f58"
 dependencies = [
  "log",
  "quick-xml",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "ssg"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-a11y"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "serde",
  "serde_json",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-core"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "log",
  "noyalib 0.0.17",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "criterion",
  "inventory",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc-macro"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-search"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4942,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-wasm"
-version = "0.0.54"
+version = "0.0.55"
 dependencies = [
  "js-sys",
  "serde-wasm-bindgen",
@@ -4967,9 +4967,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "staticdatagen"
-version = "0.0.12"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4703ed55d7d9579e921929d3729ef0f370d4bd51d10a171bb9ab035a4bcf0e2"
+checksum = "0728f05e1dfa18a9dedfa7bd2d061e6ed36ec0442db1e2fc1cfbb3b7b2981998"
 dependencies = [
  "anyhow",
  "comrak 0.54.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "ssg"                            # The name of the library
-version = "0.0.54"                      # The version of the library
+version = "0.0.55"                      # The version of the library
 authors = ["SSG Contributors"]     # The authors of the library
 edition = "2021"                        # The edition of the library
 rust-version = "1.88.0"                 # Minimum supported Rust version (set by time-macros, staticdatagen, oxc_*)
@@ -181,12 +181,12 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["html
 rayon = "1.12.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.54" }
-ssg-core = { path = "crates/ssg-core", version = "0.0.54" }
-ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.54" }
-ssg-search = { path = "crates/ssg-search", version = "0.0.54" }
+ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.55" }
+ssg-core = { path = "crates/ssg-core", version = "0.0.55" }
+ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.55" }
+ssg-search = { path = "crates/ssg-search", version = "0.0.55" }
 thiserror = "2"
-staticdatagen = "0.0.12"
+staticdatagen = "0.0.13"
 toml = "1.1.2"
 
 # Real cryptographic hashing for Subresource Integrity (issue #468 follow-up).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.54-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.55-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -41,7 +41,7 @@
 
 ```toml
 [dependencies]
-ssg = "0.0.54"
+ssg = "0.0.55"
 ```
 
 ### Prebuilt binaries

--- a/crates/ssg-a11y/Cargo.toml
+++ b/crates/ssg-a11y/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-a11y"
-version = "0.0.54"
+version = "0.0.55"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-core"
-version = "0.0.54"
+version = "0.0.55"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc-macro"
-version = "0.0.54"
+version = "0.0.55"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc/Cargo.toml
+++ b/crates/ssg-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc"
-version = "0.0.54"
+version = "0.0.55"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ schemars = { version = "1.2", default-features = false, features = ["derive", "s
 thiserror = "2"
 
 # Re-export the proc-macro so users only depend on `ssg-rpc`.
-ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.54" }
+ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.55" }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/ssg-search/Cargo.toml
+++ b/crates/ssg-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-search"
-version = "0.0.54"
+version = "0.0.55"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-wasm/Cargo.toml
+++ b/crates/ssg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-wasm"
-version = "0.0.54"
+version = "0.0.55"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Four fixes. **Three were shipping corrupted output while the build reported success** — which is why they survived so long.

| | |
|---|---|
| #706 / #708 | `og:title` double-escaped `&` **since 0.0.46** — 1,494 pages on one corpus |
| #710 | slug-colliding taxonomy terms overwrote each other; builds not reproducible |
| #712 | search results linked to the host root — 29 live 404s |
| staticdatagen 0.0.13 | structured data requested from a fragment that cannot supply it |

Also bumps `staticdatagen` 0.0.12 → 0.0.13, which is how the fourth arrives.

## Why each is worse than it looks

**#706** is not the 0.0.52 regression it was first reported as. Bisecting the published binaries against one identical input file puts the first bad release at **0.0.46** — the release that *closed* #589, the same symptom. #589 was half-fixed: `staticweaver` was made entity-aware, our own call site was left alone, and nothing asserted `escape(escape(x)) == escape(x)`. Both pre-existing tests pass against the broken code because they only ever fed it raw characters.

**#710** was a determinism bug hiding a content bug: `/tags/swift/` listed one spelling's pages and silently dropped the other's, with the survivor decided per process by hash iteration order.

**#712** is the worse half of the 0.0.54 search fix. Fixing the fetch alone made the failure *less* visible — search opened, results rendered, and only clicking one revealed a 404.

**staticdatagen** was failing on every page ever compiled and logging at Error each time.

## Verification

`docs_accuracy` **run before pushing** — it is the gate that caught the 0.0.52 cut mid-flight:

```
docs_accuracy                          12 passed
cargo fmt --all -- --check             clean
cargo clippy --lib --all-features      clean
cargo test --lib --all-features        3633 passed, 0 failed
```

All under **clippy 0.1.98 / rustfmt 1.9.0** — the toolchain CI resolves from `channel = "stable"`. A local `RUSTUP_TOOLCHAIN` export pins to 1.97, which cannot see the lints CI denies; `cargo +1.98.0` is the invocation that matches.

12 version pins plus both README claims. The README refs are the half a `^version`-anchored sed misses — the internal dependency references in the root `Cargo.toml` and `crates/ssg-rpc`.

Related: #711 (four duplicate tag scanners, found while tracing #706) is deliberately **not** in here — a refactor does not belong in a release blocker.