### PR TITLE
chore(release): 0.0.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.56] - 2026-08-21
+
+Three defects that only appeared in configurations nobody was checking.
+
+### Fixed
+
+- **The placeholder site title reached rendered pages** (#705). `DEFAULT_SITE_TITLE`
+  was `"My SSG Site"`, so a site that never set `site_title` shipped that string
+  in its `<title>` — 7,189 live pages on one corpus. The unit test asserting the
+  default pinned the placeholder itself (`assert_eq!(default, "My SSG Site")`), so
+  it stayed green the entire time it was wrong. The default is now empty, and the
+  templates omit the suffix rather than inventing branding.
+
+- **A configured site title was dropped without the `templates` feature** (#705).
+  `default = ["templates", ...]`, so `--no-default-features` selects the
+  hand-written renderer — and `site_title` was read only in the minijinja path.
+  The same config therefore produced differently branded pages depending on how
+  the binary was compiled. The fallback now mirrors the template exactly, and the
+  tests covering it are deliberately ungated so both renderers must agree.
+
+- **Entity-encoded `<title>` text reached consumers double-escaped** (#705).
+  `lol_html` hands text through without unescaping, so `extract_title` returns
+  encoded text; decoding is now explicit, with `&amp;` decoded last so a literal
+  `&amp;lt;` in a title does not collapse into `<`.
+
+### Testing
+
+- Every shipped example is now exercised. The per-example assertions covered 7 of
+  18; a fleet sweep runs the rest and pins the discovered set against cargo's own
+  view, so a newly added example cannot go untested silently.
+
 ## [0.0.55] - 2026-08-21
 
 Four fixes. Three were shipping corrupted output while looking healthy.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "ssg"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-a11y"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "serde",
  "serde_json",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-core"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "log",
  "noyalib 0.0.17",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "criterion",
  "inventory",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc-macro"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4928,7 +4928,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-search"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4942,7 +4942,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-wasm"
-version = "0.0.55"
+version = "0.0.56"
 dependencies = [
  "js-sys",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "ssg"                            # The name of the library
-version = "0.0.55"                      # The version of the library
+version = "0.0.56"                      # The version of the library
 authors = ["SSG Contributors"]     # The authors of the library
 edition = "2021"                        # The edition of the library
 rust-version = "1.88.0"                 # Minimum supported Rust version (set by time-macros, staticdatagen, oxc_*)
@@ -181,10 +181,10 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["html
 rayon = "1.12.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.55" }
-ssg-core = { path = "crates/ssg-core", version = "0.0.55" }
-ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.55" }
-ssg-search = { path = "crates/ssg-search", version = "0.0.55" }
+ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.56" }
+ssg-core = { path = "crates/ssg-core", version = "0.0.56" }
+ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.56" }
+ssg-search = { path = "crates/ssg-search", version = "0.0.56" }
 thiserror = "2"
 staticdatagen = "0.0.13"
 toml = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.55-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.56-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -41,7 +41,7 @@
 
 ```toml
 [dependencies]
-ssg = "0.0.55"
+ssg = "0.0.56"
 ```
 
 ### Prebuilt binaries

--- a/crates/ssg-a11y/Cargo.toml
+++ b/crates/ssg-a11y/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-a11y"
-version = "0.0.55"
+version = "0.0.56"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-core"
-version = "0.0.55"
+version = "0.0.56"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc-macro"
-version = "0.0.55"
+version = "0.0.56"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc/Cargo.toml
+++ b/crates/ssg-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc"
-version = "0.0.55"
+version = "0.0.56"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ schemars = { version = "1.2", default-features = false, features = ["derive", "s
 thiserror = "2"
 
 # Re-export the proc-macro so users only depend on `ssg-rpc`.
-ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.55" }
+ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.56" }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/ssg-search/Cargo.toml
+++ b/crates/ssg-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-search"
-version = "0.0.55"
+version = "0.0.56"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-wasm/Cargo.toml
+++ b/crates/ssg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-wasm"
-version = "0.0.55"
+version = "0.0.56"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Ships three defects that only appeared in configurations nobody was checking, plus the example coverage that would have caught the third.

## Fixed

**The placeholder site title reached rendered pages** (#705)
`DEFAULT_SITE_TITLE` was `"My SSG Site"`, so a site that never set `site_title` shipped that string in its `<title>` — 7,189 live pages on one corpus. The unit test asserting the default pinned the placeholder itself (`assert_eq!(default, "My SSG Site")`), so it stayed green the entire time it was wrong.

**A configured site title was dropped without the `templates` feature** (#705)
`default = ["templates", …]`, so `--no-default-features` selects the hand-written renderer — and `site_title` was read only in the minijinja path. The same config produced differently branded pages depending on how the binary was compiled. Caught by the coverage gate, which is the one configuration local runs skip.

**Entity-encoded `<title>` text reached consumers double-escaped** (#705)
`lol_html` hands text through without unescaping, so `extract_title` returns encoded text. Decoding is now explicit, with `&amp;` decoded **last** so a literal `&amp;lt;` in a title does not collapse into `<`.

## Testing

Every shipped example is now exercised. The per-example assertions covered **7 of 18**; a fleet sweep runs the rest and pins the discovered set against cargo’s own view, so a newly added example cannot go untested silently.

## Release mechanics

14 references bumped — 12 version pins plus both README claims. Zero `0.0.55` strings remain.

- `docs_accuracy`: **12 passed**, run before pushing
- `cargo metadata`: resolves clean
- `Cargo.lock` regenerated

Same 10 files as the 0.0.55 release commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)