### PR TITLE
refactor(audit): one tag-end scanner in the root crate, not three

### DIFF
--- a/src/audit/gates/wcag.rs
+++ b/src/audit/gates/wcag.rs
@@ -9,6 +9,7 @@
 //! Findings map directly to WCAG success-criteria codes.
 
 use super::super::{AuditGate, AuditOptions, Finding, Severity, Site};
+use super::util;
 
 const NAME: &str = "wcag";
 
@@ -105,7 +106,7 @@ fn check_img_alt(html: &str, out: &mut Vec<Issue>) {
     let mut pos = 0;
     while let Some(start) = lower[pos..].find("<img") {
         let abs = pos + start;
-        let tag_end = find_tag_end(&lower, abs);
+        let tag_end = util::find_tag_end(&lower, abs);
         let tag = &lower[abs..tag_end];
         // Attribute-based lookup: minifiers collapse `alt=""` to a bare
         // valueless `alt`, and unquoted `alt=x` is legal — both count.
@@ -197,26 +198,6 @@ fn check_aria_landmarks(html: &str, out: &mut Vec<Issue>) {
             format!("Page has {main_count} <main> elements (expected 1)"),
         );
     }
-}
-
-const fn find_tag_end(html: &str, tag_start: usize) -> usize {
-    let bytes = html.as_bytes();
-    let mut i = tag_start;
-    let mut quote: Option<u8> = None;
-    while i < bytes.len() {
-        let b = bytes[i];
-        match quote {
-            Some(q) if b == q => quote = None,
-            Some(_) => {}
-            None => match b {
-                b'"' | b'\'' => quote = Some(b),
-                b'>' => return i + 1,
-                _ => {}
-            },
-        }
-        i += 1;
-    }
-    bytes.len()
 }
 
 #[cfg(test)]
@@ -418,9 +399,9 @@ mod tests {
     #[test]
     fn unterminated_tag_end_is_input_len() {
         let html = "<img src='x";
-        assert_eq!(find_tag_end(html, 0), html.len());
+        assert_eq!(util::find_tag_end(html, 0), html.len());
         let quoted = "<img alt=\"a>b\">";
-        assert_eq!(find_tag_end(quoted, 0), quoted.len());
+        assert_eq!(util::find_tag_end(quoted, 0), quoted.len());
     }
 
     #[test]

--- a/src/plugins/seo/jsonld/mod.rs
+++ b/src/plugins/seo/jsonld/mod.rs
@@ -8,6 +8,7 @@ use super::helpers::{
     extract_meta_author, extract_meta_date, extract_title,
 };
 use super::lang::resolve_page_lang;
+use crate::audit::gates::util::find_tag_end;
 use crate::error::SsgError;
 use crate::plugin::{Plugin, PluginContext};
 use crate::util::head_dom::inject_before_head_close;
@@ -548,7 +549,7 @@ fn extract_jsonld_blocks(html: &str) -> Vec<String> {
         // skipping any `>` characters that appear inside quoted
         // attribute values. Without this, `<script type="text/x>y">`
         // would close prematurely at the inner `>`.
-        let tag_end = find_html_tag_end(&lower, abs_open);
+        let tag_end = find_tag_end(&lower, abs_open);
         let tag = &lower[abs_open..tag_end];
         cursor = tag_end;
 
@@ -645,29 +646,6 @@ fn find_script_close_skipping_strings(body: &str) -> Option<usize> {
         i += 1;
     }
     None
-}
-
-/// Like `accessibility::find_tag_end` — returns the index just past
-/// the `>` that closes the open tag at `tag_start`, while skipping
-/// `>` characters that occur inside quoted attribute values.
-const fn find_html_tag_end(html: &str, tag_start: usize) -> usize {
-    let bytes = html.as_bytes();
-    let mut i = tag_start;
-    let mut quote: Option<u8> = None;
-    while i < bytes.len() {
-        let b = bytes[i];
-        match quote {
-            Some(q) if b == q => quote = None,
-            Some(_) => {}
-            None => match b {
-                b'"' | b'\'' => quote = Some(b),
-                b'>' => return i + 1,
-                _ => {}
-            },
-        }
-        i += 1;
-    }
-    bytes.len()
 }
 
 /// Validates a single parsed JSON-LD value (object or array).
@@ -1469,7 +1447,7 @@ mod tests {
     #[test]
     fn find_html_tag_end_without_closing_bracket_returns_len() {
         let html = "<script type=\"application/ld+json\"";
-        assert_eq!(find_html_tag_end(html, 0), html.len());
+        assert_eq!(find_tag_end(html, 0), html.len());
     }
 
     // ── validate_one: remaining shapes ──────────────────────────────


### PR DESCRIPTION
Closes #711 for the root crate — three copies become one.

| location | was |
|---|---|
| `src/audit/gates/util.rs` | `find_tag_end` — **kept, already `pub`** |
| `src/audit/gates/wcag.rs` | `find_tag_end` — removed, delegates |
| `src/plugins/seo/jsonld/mod.rs` | `find_html_tag_end` — removed, delegates |
| `crates/ssg-a11y/src/html.rs` | `find_tag_end` — **deliberately kept** |

## Behaviour-preserving

The bodies were byte-identical apart from visibility (`pub` / `pub(crate)` / private). I diffed them before merging rather than assuming — they had drifted in name and visibility but not in logic.

## Why it was worth doing

When clippy 1.98 added `missing_const_for_fn`, it fired on **each copy separately**, and because cargo halts at the first failing crate it surfaced one at a time — four sequential CI round-trips for one function.

It is also the shape that produced #706: a naive `escape_attr` sat beside an entity-aware `escape_html_into`, they disagreed, and the wrong one won at one call site for thirteen releases. Duplicated logic does not fail together; it fails *differently*, which is what makes it expensive.

## Why `ssg-a11y` keeps its copy

That crate is published as *"Standalone WCAG 2.2 AA accessibility checker — build-time HTML validation, framework-agnostic"* and depends only on `serde`/`serde_json`. Adding an `ssg-core` dependency to share fifteen lines would contradict its stated purpose and its published description.

Fifteen duplicated lines is the smaller cost. So this closes three of four and says so, rather than forcing the fourth and calling the issue done.

## Verification

No coverage lost — the deleted copies' cases were already covered by `find_tag_end_returns_len_when_unterminated`; util's four tests pass against the shared implementation.

```
cargo fmt --all -- --check             clean
cargo clippy --lib --all-features      clean
cargo test --lib --all-features        3642 passed, 0 failed
```

Under clippy 0.1.98 / rustfmt 1.9.0 — the toolchain CI resolves from `channel = "stable"`.