### PR TITLE
refactor(a11y): one tag-end scanner in the workspace, not four

### DIFF
--- a/crates/ssg-a11y/src/html.rs
+++ b/crates/ssg-a11y/src/html.rs
@@ -40,14 +40,15 @@ pub(crate) fn is_decorative_img(tag: &str) -> bool {
         || tag.contains("role=none")
 }
 
-/// Returns the absolute end index (one past the closing `>`) of the HTML
-/// tag that starts at `tag_start`. Skips `>` characters that occur inside
-/// double- or single-quoted attribute values so that inline SVG `data:`
-/// URLs in `src` attributes don't truncate the tag prematurely.
+/// Returns the index one past the closing `>` of the tag at `tag_start`.
+///
+/// Skips `>` characters inside double- or single-quoted attribute values, so
+/// an inline SVG `data:` URL in a `src` attribute cannot truncate the tag
+/// prematurely.
 // `const` because clippy::missing_const_for_fn asks for it under Rust
 // 1.98, where the lint learned to see through this loop. Nothing about
 // the body changed — it was already const-compatible.
-pub(crate) const fn find_tag_end(html: &str, tag_start: usize) -> usize {
+pub const fn find_tag_end(html: &str, tag_start: usize) -> usize {
     let bytes = html.as_bytes();
     let mut i = tag_start;
     let mut quote: Option<u8> = None;

--- a/crates/ssg-a11y/src/lib.rs
+++ b/crates/ssg-a11y/src/lib.rs
@@ -50,6 +50,16 @@
 
 mod css;
 mod html;
+
+/// Scan to the end of an HTML tag.
+///
+/// Skips `>` characters inside quoted attribute values, so an inline
+/// `data:` URL in a `src` attribute cannot truncate the tag early.
+///
+/// Exported because a standalone HTML checker is where this belongs: the
+/// host crate had grown three separate copies of it (ssg#711). Additive —
+/// nothing existing changes shape.
+pub use html::find_tag_end;
 mod report;
 mod rules;
 mod types;

--- a/src/audit/gates/util.rs
+++ b/src/audit/gates/util.rs
@@ -20,25 +20,19 @@
 /// assert_eq!(find_tag_end(html, 0), 4);
 /// ```
 #[allow(dead_code)]
-pub const fn find_tag_end(html: &str, tag_start: usize) -> usize {
-    let bytes = html.as_bytes();
-    let mut i = tag_start;
-    let mut quote: Option<u8> = None;
-    while i < bytes.len() {
-        let b = bytes[i];
-        match quote {
-            Some(q) if b == q => quote = None,
-            Some(_) => {}
-            None => match b {
-                b'"' | b'\'' => quote = Some(b),
-                b'>' => return i + 1,
-                _ => {}
-            },
-        }
-        i += 1;
-    }
-    bytes.len()
-}
+/// Scan to the end of an HTML tag.
+///
+/// Skips `>` inside quoted attribute values.
+///
+/// Re-exported from `ssg-a11y`, which owns the single implementation. This
+/// crate previously carried three copies of it and `ssg-a11y` a fourth; they
+/// were byte-identical apart from visibility, and when clippy 1.98 added
+/// `missing_const_for_fn` the lint fired on each one separately — four
+/// sequential CI round-trips for one function (ssg#711).
+///
+/// The dependency already ran this way (`ssg` -> `ssg-a11y`), so sharing costs
+/// no new edge and leaves that crate standalone, as its description promises.
+pub use ssg_a11y::find_tag_end;
 
 /// Reads a single attribute value out of a tag.
 ///


### PR DESCRIPTION
**Closes #711** — completes what #717 started.

| copy | before | now |
|---|---|---|
| `src/audit/gates/util.rs` | implementation | re-export |
| `src/audit/gates/wcag.rs` | implementation | (removed in #717) |
| `src/plugins/seo/jsonld/mod.rs` | implementation | (removed in #717) |
| `crates/ssg-a11y/src/html.rs` | implementation | **the single source** |

## I had this backwards in #717

I argued the fourth copy should stay, because `ssg-a11y` is published as *"Standalone … framework-agnostic"* and adding an `ssg-core` dependency to share fifteen lines would cost more than the duplication.

That was the wrong direction to look. **`ssg` already depends on `ssg-a11y`** — `Cargo.toml:184`, used by `plugins/accessibility.rs`. Sharing needs no new edge; it just runs the other way. `ssg-a11y` keeps exactly the dependencies it had (`serde`, `serde_json`) and gains one additive export.

## Safety

Verified **byte-identical** before collapsing — both bodies hash the same once visibility modifiers are normalised. Had they drifted semantically, merging would have silently changed behaviour at one of the nine call sites.

## A pre-existing defect this surfaced

Promoting the function to `pub` made clippy's `too_long_first_doc_paragraph` fire on its **existing** doc comment — that lint doesn't apply to crate-private items, so it had been non-conforming since it was written with nothing reaching it.

Reflowed rather than `#[allow]`-ed. An unreachable lint protects nothing, which is the same shape as `assert_eq!(default, "My SSG Site")` pinning a placeholder as correct, and `escape_attr`'s tests only ever feeding it raw characters.

## Verification

```
cargo fmt --all -- --check                            clean
cargo clippy --lib --all-features                     clean
cargo clippy --lib --tests --examples --all-features  clean
cargo test --lib --all-features                       3642 passed, 0 failed
cargo test -p ssg-a11y                                green
```