### PR TITLE
fix(meta): inject into <head> with a parser at every site

### DIFF
--- a/src/plugins/oembed.rs
+++ b/src/plugins/oembed.rs
@@ -142,9 +142,6 @@ impl Plugin for OembedPlugin {
         if !sibling.exists() {
             return Ok(html.to_string());
         }
-        let Some(pos) = html.find("</head>") else {
-            return Ok(html.to_string());
-        };
 
         let rel = path
             .strip_prefix(&ctx.site_dir)
@@ -169,7 +166,11 @@ impl Plugin for OembedPlugin {
             attr_escape(&href),
             attr_escape(&title),
         );
-        Ok(format!("{}{}{}", &html[..pos], link, &html[pos..]))
+        // Parser-backed injection, not a `find("</head>")` splice: the
+        // first byte match may be inside a comment or a script body in the
+        // head, and the payload would land there — inert, and silently so,
+        // because the document still parses (ssg#540).
+        Ok(crate::util::head_dom::inject_before_head_close(html, &link))
     }
 }
 

--- a/src/plugins/view_transitions.rs
+++ b/src/plugins/view_transitions.rs
@@ -146,11 +146,11 @@ impl Plugin for ViewTransitionsPlugin {
 
         // Inject style into <head> when present so persistent
         // transition roots are named before paint.
-        let with_style = if let Some(pos) = html.find("</head>") {
-            format!("{}{head_block}{}", &html[..pos], &html[pos..])
-        } else {
-            html.to_string()
-        };
+        // Parser-backed: a `</head>` inside a comment or script in the head
+        // is not the head's end tag, and a byte splice cannot tell the
+        // difference (ssg#540).
+        let with_style =
+            crate::util::head_dom::inject_before_head_close(html, &head_block);
 
         // Inject script just before </body> so the DOM is ready.
         let with_script = if let Some(pos) = with_style.rfind("</body>") {

--- a/src/util/head_dom.rs
+++ b/src/util/head_dom.rs
@@ -373,6 +373,48 @@ mod entity_decode_tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+
+    /// ssg#540: a `</head>` that appears inside a comment or a script in the
+    /// head is not the head's end tag. A `find("</head>")` splice takes the
+    /// first byte match and injects *inside* that comment, where the payload
+    /// is inert — silently, because the output still looks like valid HTML.
+    #[test]
+    fn injection_ignores_a_head_close_inside_a_comment() {
+        let html = concat!(
+            "<html><head>",
+            "<!-- </head> -->",
+            "<title>T</title>",
+            "</head><body></body></html>"
+        );
+        let out = inject_before_head_close(html, "<meta name=\"x\">");
+
+        let naive = html.find("</head>").unwrap();
+        let real = out.find("<meta name=\"x\">").unwrap();
+        assert!(
+            real > naive,
+            "payload landed at the commented-out tag, not the real one: {out}"
+        );
+        assert!(
+            out.contains("<meta name=\"x\"></head>"),
+            "payload should sit immediately before the real close: {out}"
+        );
+    }
+
+    /// The same hazard written as a script body rather than a comment.
+    #[test]
+    fn injection_ignores_a_head_close_inside_a_script() {
+        let html = concat!(
+            "<html><head>",
+            "<script>var s = \"</head>\";</script>",
+            "</head><body></body></html>"
+        );
+        let out = inject_before_head_close(html, "<meta name=\"y\">");
+        assert!(
+            out.contains("<meta name=\"y\"></head>"),
+            "payload should sit before the real close: {out}"
+        );
+    }
+
     use super::*;
 
     // ── inject_before_head_close ────────────────────────────────────


### PR DESCRIPTION
Addresses #540.

`oembed.rs` and `view_transitions.rs` each did:

```rust
let Some(pos) = html.find("</head>") else { ... };
format!("{}{payload}{}", &html[..pos], &html[pos..])
```

A `</head>` inside a comment or a script body **in the head** is not the head's end tag. The splice takes the first byte match, so the payload lands inside the decoy — inert, and silently so, because the document still parses.

Both now call the shared `head_dom::inject_before_head_close`, which was already `lol_html`-backed.

## Two of the issue's premises did not hold

Worth stating so the issue isn't treated as an accurate map of the tree:

- It warns that `String::replace` replaces **every** `</head>`. **No replace-based head injection exists** — I searched. Either it was fixed earlier or the description was aspirational.
- `i18n.rs` appears to hold a second implementation. It is a **thin shim** (`use crate::util::head_dom::inject_before_head_close as inject_head`) over the same helper — there was never a duplicate to reconcile.

The real defect was two callers bypassing a correct helper.

## Verified the helper before trusting it

I did not assume the shared path was safe. Two new tests place a `</head>` decoy inside a comment and inside a script body, then assert the payload lands before the **real** close:

```
injection_ignores_a_head_close_inside_a_comment   ok
injection_ignores_a_head_close_inside_a_script    ok
```

Both passed against the existing helper, so this PR is a migration rather than a repair.

## Result

**Zero production byte-scans for `</head>` remain.** The six matches left are in tests and in the comments explaining why.

No regression — oembed **24** tests, view_transitions **28**, all green.

```
cargo fmt --all -- --check                            clean
cargo clippy --lib --all-features                     clean
cargo clippy --lib --tests --examples --all-features  clean
cargo test --lib --all-features                       3644 passed, 0 failed
```