### PR TITLE
fix(csp): stop commented-out blocks reaching the policy and the filesystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -293,6 +293,12 @@ tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter
 name = "bench"
 harness = false
 
+# HTML scanning paths that moved to a parser in #539/#540/#570. Tracks the
+# throughput cost of correctness so it stays a number, not a surprise.
+[[bench]]
+name = "bench_html_scanning"
+harness = false
+
 # AVIF-vs-WebP encoder comparison (issue #521 AC3). Standalone bench
 # rather than a sibling of `plugins/og_image.rs` because criterion
 # `bench_function`s rooted at the workspace top-level are what the

--- a/benches/baselines/criterion-json/html_scanning.json
+++ b/benches/baselines/criterion-json/html_scanning.json
@@ -1,0 +1,46 @@
+{
+  "$comment": [
+    "Baseline for the HTML paths that moved from byte scans to a parser in",
+    "ssg#539, #540 and #570. Committed so the throughput cost of that",
+    "correctness stays a tracked number rather than something rediscovered",
+    "by bisecting a slow build.",
+    "",
+    "Recorded on Apple Silicon (aarch64-apple-darwin), rustc 1.98.0, release",
+    "profile, criterion --warm-up-time 1 --measurement-time 2. Absolute",
+    "figures are machine-specific: compare ratios between runs on one",
+    "machine, never these numbers against a different one.",
+    "",
+    "`decoy` inputs carry a commented-out block ahead of the real one. That",
+    "is the shape the old byte scans got wrong -- a commented `<script>` was",
+    "hashed into CSP and hoisted into a real external file -- so it is the",
+    "shape worth tracking."
+  ],
+  "recorded": "2026-08-21",
+  "machine": "aarch64-apple-darwin",
+  "rustc": "1.98.0",
+  "unit": "median",
+  "benchmarks": {
+    "html_scanning::inject_before_head_close/clean": { "median_us": 5.1544, "low_us": 5.0611, "high_us": 5.2561 },
+    "html_scanning::inject_before_head_close/decoy": { "median_us": 4.7891, "low_us": 4.6736, "high_us": 4.9117 },
+    "html_scanning::extract_head_meta/clean":        { "median_us": 6.3457, "low_us": 6.2318, "high_us": 6.4722 },
+    "html_scanning::extract_head_meta/decoy":        { "median_us": 6.2503, "low_us": 6.1976, "high_us": 6.3052 },
+    "html_scanning::find_tag_end/plain":             { "median_ns": 20.130, "low_ns": 19.793, "high_ns": 20.424 },
+    "html_scanning::find_tag_end/quoted_gt":         { "median_ns": 35.809, "low_ns": 35.045, "high_ns": 36.529 }
+  },
+  "known_regression": {
+    "benchmark": "gates::csp_sri",
+    "before_us": 43.696,
+    "after_us": 51.082,
+    "delta_pct": 16.9,
+    "note": [
+      "Measured A/B on one machine, main vs this branch, confidence",
+      "intervals non-overlapping ([42.461, 45.081] vs [49.410, 52.764]),",
+      "so the effect is real rather than noise.",
+      "",
+      "This is the price of #570: collect_inline_contents went from a",
+      "memchr-backed byte scan to a real HTML parser. The parser is what",
+      "stops commented-out scripts being hashed into CSP and hoisted into",
+      "external files. Recorded as a regression, not dressed up as a win."
+    ]
+  }
+}

--- a/benches/bench_html_scanning.rs
+++ b/benches/bench_html_scanning.rs
@@ -1,0 +1,115 @@
+// Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Benchmarks for the HTML paths that moved from byte scans to a parser.
+//!
+//! ssg#539, #540 and #570 replaced `str::find` scans with `lol_html` (or,
+//! where the caller reassembles the document by string surgery, with
+//! comment masking). Those scans matched their target bytes inside HTML
+//! comments, so a commented-out `<script>` was hashed into CSP and hoisted
+//! into a real external file.
+//!
+//! Correctness cost throughput, and this exists so the cost is a tracked
+//! number rather than something rediscovered by bisecting a slow build. A
+//! parser builds a state machine; `memchr` does not. The regression is the
+//! price of the fix, not a defect in it.
+//!
+//! Each input comes in two shapes: `clean`, and `decoy` — the same document
+//! with a commented-out block ahead of the real one. The decoy is the case
+//! the old code got wrong, so it is the case worth measuring.
+
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+/// A page with a realistic head: several meta tags, a stylesheet, a script.
+fn page(decoy: bool) -> String {
+    let mut s = String::from("<!DOCTYPE html><html lang=\"en\"><head>");
+    if decoy {
+        s.push_str("<!-- <meta name=\"description\" content=\"OLD\"> -->");
+        s.push_str("<!-- <script>legacy()</script> -->");
+        s.push_str("<!-- </head> -->");
+    }
+    s.push_str("<title>Benchmark Page</title>");
+    for i in 0..12 {
+        s.push_str(&format!(
+            "<meta name=\"m{i}\" content=\"value {i} with some length to it\">"
+        ));
+    }
+    s.push_str("<meta name=\"description\" content=\"REAL\">");
+    s.push_str("<link rel=\"canonical\" href=\"https://example.com/p\">");
+    s.push_str("<style>.a{color:red}.b{color:blue}</style>");
+    s.push_str("<script>window.x=1;window.y=2;</script>");
+    s.push_str("</head><body><main><p>Body copy.</p></main></body></html>");
+    s
+}
+
+fn bench_head_injection(c: &mut Criterion) {
+    let clean = page(false);
+    let decoy = page(true);
+    let payload = "<meta name=\"injected\" content=\"1\">";
+
+    let mut g = c.benchmark_group("html_scanning::inject_before_head_close");
+    let _ = g.bench_function("clean", |b| {
+        b.iter(|| {
+            ssg::util::head_dom::inject_before_head_close(
+                black_box(&clean),
+                black_box(payload),
+            )
+        });
+    });
+    // The shape the byte splice got wrong: it injected inside the comment.
+    let _ = g.bench_function("decoy", |b| {
+        b.iter(|| {
+            ssg::util::head_dom::inject_before_head_close(
+                black_box(&decoy),
+                black_box(payload),
+            )
+        });
+    });
+    g.finish();
+}
+
+fn bench_head_meta(c: &mut Criterion) {
+    let clean = page(false);
+    let decoy = page(true);
+
+    let mut g = c.benchmark_group("html_scanning::extract_head_meta");
+    let _ = g.bench_function("clean", |b| {
+        b.iter(|| ssg::util::head_dom::extract_head_meta(black_box(&clean)));
+    });
+    let _ = g.bench_function("decoy", |b| {
+        b.iter(|| ssg::util::head_dom::extract_head_meta(black_box(&decoy)));
+    });
+    g.finish();
+}
+
+fn bench_tag_end(c: &mut Criterion) {
+    // The scanner #711 collapsed from four copies to one. Two shapes: a
+    // plain tag, and one whose attribute value contains `>` — the case the
+    // skip logic exists for.
+    let plain = "<img src=\"a.png\" alt=\"plain\">rest";
+    let quoted =
+        "<img src=\"data:image/svg+xml,<svg><path d='M0 0'/></svg>\" alt=\"x\">rest";
+
+    let mut g = c.benchmark_group("html_scanning::find_tag_end");
+    let _ = g.bench_function("plain", |b| {
+        b.iter(|| {
+            ssg::audit::gates::find_tag_end(black_box(plain), black_box(0))
+        });
+    });
+    let _ = g.bench_function("quoted_gt", |b| {
+        b.iter(|| {
+            ssg::audit::gates::find_tag_end(black_box(quoted), black_box(0))
+        });
+    });
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_head_injection,
+    bench_head_meta,
+    bench_tag_end
+);
+criterion_main!(benches);

--- a/src/plugins/csp.rs
+++ b/src/plugins/csp.rs
@@ -160,7 +160,7 @@ pub fn page_inline_hashes(html: &str) -> PageCspHashes {
 
     let mut scripts = Vec::new();
     for content in collect_inline_contents(html, "script") {
-        let h = hash(content);
+        let h = hash(&content);
         if !scripts.contains(&h) {
             scripts.push(h);
         }
@@ -168,7 +168,7 @@ pub fn page_inline_hashes(html: &str) -> PageCspHashes {
 
     let mut styles = Vec::new();
     for content in collect_inline_contents(html, "style") {
-        let h = hash(content);
+        let h = hash(&content);
         if !styles.contains(&h) {
             styles.push(h);
         }
@@ -257,47 +257,59 @@ pub fn page_policy(html: &str) -> Option<String> {
 /// Collects the raw inner contents of every non-empty inline
 /// `<tag>…</tag>` block, in document order. `<script>` elements with
 /// a `src=` attribute are skipped (they are external, not inline).
-fn collect_inline_contents<'a>(html: &'a str, tag: &str) -> Vec<&'a str> {
-    let open = format!("<{tag}");
-    let close = format!("</{tag}>");
-    let mut out = Vec::new();
-    let mut from = 0;
+fn collect_inline_contents(html: &str, tag: &str) -> Vec<String> {
+    use std::cell::RefCell;
+    use std::rc::Rc;
 
-    while let Some(pos) = html[from..].find(&open) {
-        let abs = from + pos;
-        let after_open = abs + open.len();
+    use lol_html::{element, end_tag, text};
 
-        // The opener must be a real tag boundary (`<script>` or
-        // `<script …>`), not a prefix of another name.
-        match html[after_open..].chars().next() {
-            Some(c) if c == '>' || c.is_ascii_whitespace() || c == '/' => {}
-            _ => {
-                from = after_open;
-                continue;
+    use crate::util::html_rewriter::rewrite_html;
+
+    // A parser, not a `<script` byte scan. The scan matched those bytes
+    // wherever they appeared, so a commented-out block was collected and
+    // hashed — CSP then carried a hash for code that can never execute, and
+    // the policy no longer described the document (ssg#570).
+    //
+    // Text arrives in chunks, so each element accumulates into its own slot
+    // and is flushed on the end tag; concatenating across elements would
+    // hash two scripts as one.
+    let done: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+    let current: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+
+    let cur_el = Rc::clone(&current);
+    let cur_tx = Rc::clone(&current);
+    let done_el = Rc::clone(&done);
+
+    let on_el = element!(tag, move |el| {
+        // `src=` means external: there is no inline body to hash.
+        if el.get_attribute("src").is_some() {
+            *cur_el.borrow_mut() = None;
+            return Ok(());
+        }
+        *cur_el.borrow_mut() = Some(String::new());
+        let sink = Rc::clone(&done_el);
+        let slot = Rc::clone(&cur_el);
+        let _ = el.on_end_tag(end_tag!(move |_end| {
+            if let Some(body) = slot.borrow_mut().take() {
+                if !body.trim().is_empty() {
+                    sink.borrow_mut().push(body);
+                }
             }
+            Ok(())
+        }));
+        Ok(())
+    });
+
+    let on_text = text!(tag, move |chunk| {
+        if let Some(buf) = cur_tx.borrow_mut().as_mut() {
+            buf.push_str(chunk.as_str());
         }
+        Ok(())
+    });
 
-        let Some(tag_end_rel) = html[abs..].find('>') else {
-            break;
-        };
-        let content_start = abs + tag_end_rel + 1;
-        let opening_tag = &html[abs..content_start];
+    let _ = rewrite_html(html, vec![on_el, on_text]);
 
-        if tag == "script" && opening_tag.contains("src=") {
-            from = content_start;
-            continue;
-        }
-
-        let Some(close_rel) = html[content_start..].find(&close) else {
-            break;
-        };
-        let content = &html[content_start..content_start + close_rel];
-        if !content.trim().is_empty() {
-            out.push(content);
-        }
-        from = content_start + close_rel + close.len();
-    }
-
+    let out = done.borrow().clone();
     out
 }
 
@@ -569,7 +581,19 @@ fn find_inline_block<'a>(
     let open = format!("<{tag}>");
     let close = format!("</{tag}>");
 
-    let start = html.find(&open)?;
+    // Same hazard as `find_inline_script`: a commented-out block would be
+    // hoisted into a real external file and the page rewritten around it.
+    let comments = comment_spans(html);
+    let mut from = 0;
+    let start = loop {
+        let rel = html[from..].find(&open)?;
+        let abs = from + rel;
+        if inside_comment(&comments, abs) {
+            from = abs + open.len();
+            continue;
+        }
+        break abs;
+    };
     let content_start = start + open.len();
     let content_end = html[content_start..].find(&close)? + content_start;
     let end = content_end + close.len();
@@ -591,13 +615,52 @@ fn find_inline_block<'a>(
 /// is the full `<script …>` including angle brackets — the caller uses
 /// it to preserve attributes such as `type=module`, `async`, `defer`,
 /// and `data-*` when rewriting the tag.
+/// Byte ranges covered by HTML comments, in document order.
+///
+/// The inline-block extractors reassemble the document by string surgery, so
+/// they cannot be swapped for a streaming parser without restructuring the
+/// whole extract-and-replace flow — on CSP/SRI code, which is not a change to
+/// make in passing. Masking the comment spans fixes the demonstrated defect
+/// exactly: a commented-out `<script>` was hoisted into a real external file
+/// and the page rewritten around it (ssg#570).
+fn comment_spans(html: &str) -> Vec<(usize, usize)> {
+    let bytes = html.as_bytes();
+    let mut spans = Vec::new();
+    let mut i = 0;
+    while let Some(rel) = html[i..].find("<!--") {
+        let start = i + rel;
+        let after = start + 4;
+        let end = html[after..]
+            .find("-->")
+            .map_or(bytes.len(), |r| after + r + 3);
+        spans.push((start, end));
+        i = end;
+        if i >= bytes.len() {
+            break;
+        }
+    }
+    spans
+}
+
+/// True when `pos` falls inside an HTML comment.
+fn inside_comment(spans: &[(usize, usize)], pos: usize) -> bool {
+    spans.iter().any(|&(s, e)| pos >= s && pos < e)
+}
+
 fn find_inline_script(html: &str) -> Option<(String, String, String, String)> {
+    let comments = comment_spans(html);
     let mut search_from = 0;
 
     loop {
         let rest = &html[search_from..];
         let start = rest.find("<script")?;
         let abs_start = search_from + start;
+
+        // A `<script` inside a comment is not a script.
+        if inside_comment(&comments, abs_start) {
+            search_from = abs_start + "<script".len();
+            continue;
+        }
 
         // Find the end of the opening tag
         let tag_end = html[abs_start..].find('>')? + abs_start;
@@ -737,6 +800,68 @@ fn compute_sri(data: &[u8], sri_algorithm: SriAlgorithm) -> String {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+
+    /// The `<style>` extractor carries the same hazard as the script one.
+    #[test]
+    fn inline_block_extraction_skips_a_commented_block() {
+        let html = concat!(
+            "<html><head>",
+            "<!-- <style>.commented{}</style> -->",
+            "<style>.real{}</style>",
+            "</head><body></body></html>"
+        );
+        let (_, content, _) =
+            find_inline_block(html, "style").expect("real style found");
+        assert_eq!(
+            content.trim(),
+            ".real{}",
+            "a commented-out style must not be hoisted: {content:?}"
+        );
+    }
+
+    /// ssg#570, second shape: the extractors that hoist inline blocks into
+    /// external files scan for the same literal bytes. Matching a
+    /// commented-out block would hoist the comment's body into a real file
+    /// and rewrite the page around it — corrupting the document, not merely
+    /// adding a spurious hash.
+    #[test]
+    fn inline_script_extraction_skips_a_commented_block() {
+        let html = concat!(
+            "<html><head>",
+            "<!-- <script>commented()</script> -->",
+            "<script>real()</script>",
+            "</head><body></body></html>"
+        );
+        let found = find_inline_script(html);
+        assert!(found.is_some(), "the real script should still be found");
+        let (_, _, content, _) = found.unwrap();
+        assert_eq!(
+            content.trim(),
+            "real()",
+            "a commented-out script must not be hoisted: {content:?}"
+        );
+    }
+
+    /// ssg#570: a `<script>` inside an HTML comment is not a script. The
+    /// byte scan collects it anyway, so CSP gains a hash for code that can
+    /// never execute — and the policy silently drifts from the document it
+    /// is meant to describe.
+    #[test]
+    fn inline_collection_skips_a_script_inside_a_comment() {
+        let html = concat!(
+            "<html><head>",
+            "<!-- <script>commented()</script> -->",
+            "<script>real()</script>",
+            "</head><body></body></html>"
+        );
+        let found = collect_inline_contents(html, "script");
+        assert_eq!(
+            found,
+            vec!["real()"],
+            "a commented-out script must not be hashed: {found:?}"
+        );
+    }
+
     use super::*;
     use tempfile::tempdir;
 


### PR DESCRIPTION
Addresses #570 — and found more than the issue implies.

Three defects in CSP handling, each **proven with a failing test before any code moved**. All three came from scanning for the literal bytes `<script` / `<style>`, which match inside HTML comments.

| function | returned | consequence |
|---|---|---|
| `collect_inline_contents` | `["commented()", "real()"]` | CSP hash for code that can never execute |
| `find_inline_script` | `"commented()"` | commented script **hoisted into a real external file** |
| `find_inline_block` | same, for `<style>` | same |

The issue frames this as tidy-up — "eliminate remaining `str::find`". The first defect is policy drift; **the other two rewrite the document around a comment**, which is corruption, not untidiness.

## Two remedies, chosen not defaulted to

**`collect_inline_contents` → `lol_html`.** It only reads, so swapping the implementation was contained. One subtlety worth flagging: text arrives in *chunks*, so each element accumulates into its own slot and flushes on the end tag — concatenating across elements would hash two adjacent scripts as one.

**The other two → comment masking, not a parser port.** They return document splits for string reassembly; porting them means restructuring the extract-and-replace flow on CSP/SRI code. That is precisely the kind of change that causes this class of bug, so I fixed the demonstrated defect exactly and recorded the reason next to the code.

## The stated AC is not met, deliberately

#570 asks for **zero** `str::find` in rewrite paths. After this PR:

| remaining | why it stays |
|---|---|
| `csp.rs:434` | parses a CSP **directive string**, not markup |
| `html_rewriter.rs:186` | finds `;` in `decode_html_entities` — text, not markup |
| `image_plugin.rs` | `#[cfg(test)]` helper; production already uses `lol_html` attributes |
| the two extractors | masked; refactor deferred with a written reason |

Every scan that could be **proven wrong** is fixed. The rest are legitimate string work. Marking the AC satisfied would be false, so I haven't.

## Verification

```
csp suite                                             78 passed
cargo test --lib --all-features                       3645 passed, 0 failed
cargo fmt --all -- --check                            clean
cargo clippy --lib --all-features                     clean
cargo clippy --lib --tests --examples --all-features  clean
```