### PR TITLE
docs(fuzz): document reproduction, and why fuzzing stays off the PR path

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,66 @@
+# Fuzzing
+
+Four libFuzzer targets covering the parsers that sit on the build
+pipeline's untrusted-input boundary. Every one of them takes bytes an
+author controls and turns them into structure the rest of the build
+trusts, which is exactly where a panic becomes a failed build and a
+mis-parse becomes wrong output.
+
+| target | drives | why it is here |
+|---|---|---|
+| `fuzz_markdown` | `pulldown-cmark` | post bodies |
+| `fuzz_frontmatter` | the frontmatter loader | YAML from `_posts/` |
+| `fuzz_html_rewrite` | `lol_html` rewriting | every postbuild pass |
+| `fuzz_shortcodes` | the shortcode expander | inline author syntax |
+
+## Running
+
+`cargo-fuzz` needs nightly — libFuzzer and the sanitizers are not on
+stable. The repository pins `channel = "stable"`, so the toolchain has to
+be named explicitly; `cargo fuzz` without `+nightly` fails against the
+pinned toolchain rather than falling back.
+
+```bash
+cargo install cargo-fuzz --locked
+cargo +nightly fuzz list
+cargo +nightly fuzz run fuzz_markdown -- -max_total_time=60
+```
+
+The first build compiles the whole dependency tree with AddressSanitizer
+(~476 crates). Expect several minutes before the first execution, and a
+separate `fuzz/target/` from the normal build cache.
+
+## Reproducing a crash
+
+A failure writes the exact input under `fuzz/artifacts/<target>/`. Replay
+it against the same target:
+
+```bash
+cargo +nightly fuzz run fuzz_markdown fuzz/artifacts/fuzz_markdown/crash-<hash>
+```
+
+The reproducer is bytes, not a description: it replays deterministically
+and does not need the corpus that found it. Commit it to
+`fuzz/corpus/<target>/` so the case is covered from then on — a crash that
+is fixed but never seeded can come back silently.
+
+Minimise before filing, so the report carries the smallest input that
+still fails:
+
+```bash
+cargo +nightly fuzz tmin fuzz_markdown fuzz/artifacts/fuzz_markdown/crash-<hash>
+```
+
+## Corpus
+
+`fuzz/corpus/<target>/` holds committed seeds. They are inputs, not
+fixtures: libFuzzer mutates from them, so a seed that exercises an unusual
+shape is worth more than a large realistic document.
+
+## CI
+
+`.github/workflows/fuzz.yml` runs each target for 300 s on a schedule and
+on manual dispatch, in fork mode so one crash does not end the run. It is
+deliberately **not** on the PR path: the sanitizer build dominates the
+runtime, and paying it on every pull request would cost more than the
+regression risk it removes between scheduled runs.


### PR DESCRIPTION
Addresses #566. **Most of it was already built** — this closes the real gap and records a decision on the rest.

| criterion | state |
|---|---|
| targets + drivers | **already present** — 4, one more than the issue lists |
| seed corpus committed | **already present** — 3–5 seeds per target |
| scheduled CI run | **already present** — `fuzz.yml`, 300 s, fork mode |
| **`fuzz/README.md`** | **missing → added** |
| 60 s smoke on every PR | **deliberately not implemented** (below) |

## The README

It documents the parts that are easy to get wrong rather than restating commands:

- `cargo fuzz` needs an explicit **`+nightly`**. The repo pins `channel = "stable"`, so the plain invocation *fails* against the pinned toolchain rather than falling back — a real stumble for anyone reproducing a crash.
- A reproducer is **bytes**: it replays deterministically and does not need the corpus that found it.
- A fixed crash that is never seeded into `fuzz/corpus/` **can come back silently**.

## Why no PR-time job — measured, not assumed

I ran it before deciding. A cold `cargo +nightly fuzz run` compiles the dependency tree with AddressSanitizer: **476 crates, ~15–20 minutes**, before a single second of fuzzing. Multiplied across four targets on every pull request, that costs far more than the regression risk it removes between scheduled runs.

The scheduled job already covers the harness at 300 s per target. If a PR-path signal is wanted later, the cheaper shape is a path-filtered job with a cached sanitizer build — not an unconditional one.

So #566's final criterion is **not met, and I am not marking it met**.

## The harness works

Verified rather than assumed:

```
fuzz_markdown: 74,600 execs @ ~6,800/s, cov 2,736 edges,
               corpus 1,676 inputs, no crash
```