### PR TITLE
chore(vet): prune the stale staticdatagen 0.0.12 exemption

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1699,10 +1699,6 @@ criteria = "safe-to-deploy"
 version = "1.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.staticdatagen]]
-version = "0.0.12"
-criteria = "safe-to-deploy"
-
 [[exemptions.string_cache]]
 version = "0.9.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
Nothing has depended on `staticdatagen 0.0.12` since #713 bumped it to
0.0.13, and 0.0.13 is covered by `[[trusted.staticdatagen]]` rather than an
exemption. The leftover entry did nothing except make every `cargo vet` run
print:

```
WARN Your supply-chain has unnecessary exemptions which could be relaxed or pruned.
```

Removed by hand rather than with `cargo vet prune`, which also drops
unrelated entries from `imports.lock`.

`cargo vet --locked` — what CI runs — succeeds, and the warning is gone:

```
Vetting Succeeded (85 fully audited, 11 partially audited, 510 exempted)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)