### PR TITLE
chore(release): 0.0.57

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -632,6 +632,7 @@ jobs:
         #   ssg-rpc          (depends on ssg-rpc-macro)
         #   ssg-search       (no internal deps)
         #   ssg-a11y         (no internal deps)
+        #   ssg-mcp          (depends on ssg-rpc, so it follows it)
         #   ssg             (depends on all of the above)
         #
         # ssg-wasm is deliberately excluded: it carries `publish = false`
@@ -693,7 +694,7 @@ jobs:
             return 1
           }
 
-          for c in ssg-core ssg-rpc-macro ssg-rpc ssg-search ssg-a11y; do
+          for c in ssg-core ssg-rpc-macro ssg-rpc ssg-search ssg-a11y ssg-mcp; do
             publish "$c" "crates/$c/Cargo.toml" --no-verify
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.57] - 2026-08-22
+
+Three defects that produced wrong output, one new crate, and a duplication
+that had been costing CI time for a week.
+
+### Fixed
+
+- **Commented-out blocks reached CSP and the filesystem** (#721). Three
+  functions scanned for the literal bytes `<script` / `<style>`, which match
+  inside HTML comments. `collect_inline_contents` hashed dead code into the
+  policy, so CSP stopped describing the document. Worse,
+  `find_inline_script` and `find_inline_block` *hoist* what they match into
+  external files and rewrite the page around it — a commented-out script
+  became a real file. Each was proven with a failing test before any code
+  moved.
+
+- **Meta tags were read by byte scan** (#719). A commented-out
+  `<meta name="twitter:image">` left over from an edit beat the live tag
+  that followed it.
+
+- **`<head>` injection took the first byte match** (#720). `oembed` and
+  `view_transitions` spliced at `html.find("</head>")`, so a `</head>`
+  inside a comment or script body in the head captured the payload — inert,
+  and silently, because the document still parses.
+
+### Added
+
+- **`ssg-mcp`** (#723): a Model Context Protocol stdio server over the
+  existing `#[ssg_rpc]` registry. Tools are not declared; the registry is
+  walked at runtime, so a tool added to ssg appears over MCP with no second
+  declaration. Note that `tools/list` reflects what the *host binary*
+  linked: ssg itself registers no production RPC yet, so the five tools
+  #576 names remain to be written.
+
+- Benchmarks for the HTML paths that moved to a parser, with a committed
+  criterion baseline, and `tools/quality_scorecard.py` — 25 measured
+  metrics that report `unmeasured` rather than guessing.
+
+### Changed
+
+- **One tag-end scanner instead of four** (#718). The copies were
+  byte-identical apart from visibility, and when clippy 1.98 added
+  `missing_const_for_fn` the lint fired on each separately — four
+  sequential CI round-trips for one function.
+
+- **One crate-level test lint allowance instead of 150 copies.** `src/lib.rs`
+  already granted it; the repetitions were redundant, and the six workspace
+  crates now carry the same line.
+
+### Performance
+
+- CSP hashing walked the document once per tag. `collect_inline_script_and_style`
+  does both in one pass: 51.082 µs → 42.596 µs, which recovers the cost of
+  the correctness fix and lands at parity with the byte scan it replaced.
+
 ## [0.0.56] - 2026-08-21
 
 Three defects that only appeared in configurations nobody was checking.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "ssg"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -4884,7 +4884,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-a11y"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "serde",
  "serde_json",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-core"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "log",
  "noyalib 0.0.17",
@@ -4906,7 +4906,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-mcp"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "schemars",
  "serde",
@@ -4916,7 +4916,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "criterion",
  "inventory",
@@ -4929,7 +4929,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-rpc-macro"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4938,7 +4938,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-search"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "ssg-wasm"
-version = "0.0.56"
+version = "0.0.57"
 dependencies = [
  "js-sys",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "ssg"                            # The name of the library
-version = "0.0.56"                      # The version of the library
+version = "0.0.57"                      # The version of the library
 authors = ["SSG Contributors"]     # The authors of the library
 edition = "2021"                        # The edition of the library
 rust-version = "1.88.0"                 # Minimum supported Rust version (set by time-macros, staticdatagen, oxc_*)
@@ -181,10 +181,10 @@ pulldown-cmark = { version = "0.13", default-features = false, features = ["html
 rayon = "1.12.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
-ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.56" }
-ssg-core = { path = "crates/ssg-core", version = "0.0.56" }
-ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.56" }
-ssg-search = { path = "crates/ssg-search", version = "0.0.56" }
+ssg-a11y = { path = "crates/ssg-a11y", version = "0.0.57" }
+ssg-core = { path = "crates/ssg-core", version = "0.0.57" }
+ssg-rpc = { path = "crates/ssg-rpc", version = "0.0.57" }
+ssg-search = { path = "crates/ssg-search", version = "0.0.57" }
 thiserror = "2"
 staticdatagen = "0.0.13"
 toml = "1.1.2"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://crates.io/crates/ssg"><img src="https://img.shields.io/crates/v/ssg.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/ssg"><img src="https://img.shields.io/badge/docs.rs-ssg-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/static-site-generator?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.56-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/ssg"><img src="https://img.shields.io/badge/lib.rs-v0.0.57-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -41,7 +41,7 @@
 
 ```toml
 [dependencies]
-ssg = "0.0.56"
+ssg = "0.0.57"
 ```
 
 ### Prebuilt binaries

--- a/crates/ssg-a11y/Cargo.toml
+++ b/crates/ssg-a11y/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-a11y"
-version = "0.0.56"
+version = "0.0.57"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-core/Cargo.toml
+++ b/crates/ssg-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-core"
-version = "0.0.56"
+version = "0.0.57"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-mcp/Cargo.toml
+++ b/crates/ssg-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-mcp"
-version = "0.0.56"
+version = "0.0.57"
 edition = "2021"
 rust-version = "1.88.0"
 description = "Model Context Protocol stdio server exposing ssg's RPC surface as MCP tools."
@@ -15,7 +15,7 @@ homepage = "https://staticsitegenerator.com"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-ssg-rpc = { path = "../ssg-rpc", version = "0.0.56" }
+ssg-rpc = { path = "../ssg-rpc", version = "0.0.57" }
 
 [dev-dependencies]
 schemars = { version = "1.2", default-features = false, features = ["derive", "std"] }

--- a/crates/ssg-rpc-macro/Cargo.toml
+++ b/crates/ssg-rpc-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc-macro"
-version = "0.0.56"
+version = "0.0.57"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-rpc/Cargo.toml
+++ b/crates/ssg-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-rpc"
-version = "0.0.56"
+version = "0.0.57"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"
@@ -27,7 +27,7 @@ schemars = { version = "1.2", default-features = false, features = ["derive", "s
 thiserror = "2"
 
 # Re-export the proc-macro so users only depend on `ssg-rpc`.
-ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.56" }
+ssg-rpc-macro = { path = "../ssg-rpc-macro", version = "0.0.57" }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/ssg-search/Cargo.toml
+++ b/crates/ssg-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-search"
-version = "0.0.56"
+version = "0.0.57"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"

--- a/crates/ssg-wasm/Cargo.toml
+++ b/crates/ssg-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssg-wasm"
-version = "0.0.56"
+version = "0.0.57"
 edition = "2021"
 rust-version = "1.88.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Three defects that produced wrong output, one new crate, and duplication cleanups.

| | |
|---|---|
| #721 | commented-out blocks reached CSP **and the filesystem** |
| #719 | meta tags read by byte scan — a commented tag beat the live one |
| #720 | `<head>` injection took the first byte match |
| #718 | one tag-end scanner instead of four |
| #723 | `ssg-mcp` — MCP stdio server over the `#[ssg_rpc]` registry |

## A gap this release closes in the release process itself

**`ssg-mcp` was missing from `release.yml`'s publish list.** Root `ssg` does not depend on it, so `cargo publish -p ssg` would not have failed — the crate would simply never have published, silently.

That is the same shape as `ssg-wasm`'s exclusion, except that one is a decision (`publish = false`) and this would have been a bug. Added after `ssg-rpc`, which it depends on.

## Verification

**14 pins**, not the 12 of previous releases — `ssg-mcp` brings two of its own — plus both README claims.

`docs_accuracy` **run before pushing**, because that is the gate that caught the 0.0.52 cut mid-flight:

```
docs_accuracy                          12 passed
cargo fmt --all -- --check             clean
cargo clippy --lib --all-features      clean
cargo build -p ssg-mcp                 0 errors
version coherence                      root + 7/7 crates at 0.0.57
```

Under **clippy 0.1.98 / rustfmt 1.9.0** — the toolchain CI resolves from `channel = "stable"`, not the 1.97 a local `RUSTUP_TOOLCHAIN` export pins.

## Note on ssg-mcp

`tools/list` reflects what the **host binary** linked. ssg registers no production `#[ssg_rpc]` yet, so the five tools #576 names still have to be written; this ships the transport they plug into.