### PR TITLE
perf(csp): single-pass collection, plus the scorecard and lint cleanup

### DIFF
--- a/benches/baselines/criterion-json/html_scanning.json
+++ b/benches/baselines/criterion-json/html_scanning.json
@@ -20,27 +20,58 @@
   "rustc": "1.98.0",
   "unit": "median",
   "benchmarks": {
-    "html_scanning::inject_before_head_close/clean": { "median_us": 5.1544, "low_us": 5.0611, "high_us": 5.2561 },
-    "html_scanning::inject_before_head_close/decoy": { "median_us": 4.7891, "low_us": 4.6736, "high_us": 4.9117 },
-    "html_scanning::extract_head_meta/clean":        { "median_us": 6.3457, "low_us": 6.2318, "high_us": 6.4722 },
-    "html_scanning::extract_head_meta/decoy":        { "median_us": 6.2503, "low_us": 6.1976, "high_us": 6.3052 },
-    "html_scanning::find_tag_end/plain":             { "median_ns": 20.130, "low_ns": 19.793, "high_ns": 20.424 },
-    "html_scanning::find_tag_end/quoted_gt":         { "median_ns": 35.809, "low_ns": 35.045, "high_ns": 36.529 }
+    "html_scanning::inject_before_head_close/clean": {
+      "median_us": 5.1544,
+      "low_us": 5.0611,
+      "high_us": 5.2561
+    },
+    "html_scanning::inject_before_head_close/decoy": {
+      "median_us": 4.7891,
+      "low_us": 4.6736,
+      "high_us": 4.9117
+    },
+    "html_scanning::extract_head_meta/clean": {
+      "median_us": 6.3457,
+      "low_us": 6.2318,
+      "high_us": 6.4722
+    },
+    "html_scanning::extract_head_meta/decoy": {
+      "median_us": 6.2503,
+      "low_us": 6.1976,
+      "high_us": 6.3052
+    },
+    "html_scanning::find_tag_end/plain": {
+      "median_ns": 20.13,
+      "low_ns": 19.793,
+      "high_ns": 20.424
+    },
+    "html_scanning::find_tag_end/quoted_gt": {
+      "median_ns": 35.809,
+      "low_ns": 35.045,
+      "high_ns": 36.529
+    }
   },
   "known_regression": {
     "benchmark": "gates::csp_sri",
-    "before_us": 43.696,
-    "after_us": 51.082,
-    "delta_pct": 16.9,
+    "status": "recovered",
+    "byte_scan_us": 43.696,
+    "two_pass_parser_us": 51.082,
+    "single_pass_parser_us": 42.596,
     "note": [
-      "Measured A/B on one machine, main vs this branch, confidence",
-      "intervals non-overlapping ([42.461, 45.081] vs [49.410, 52.764]),",
-      "so the effect is real rather than noise.",
+      "The first parser version walked the document once per tag, so",
+      "hashing a page cost two full parses and ran 16.9% slower than the",
+      "byte scan it replaced ([49.410, 52.764] vs [42.461, 45.081],",
+      "non-overlapping).",
       "",
-      "This is the price of #570: collect_inline_contents went from a",
-      "memchr-backed byte scan to a real HTML parser. The parser is what",
-      "stops commented-out scripts being hashed into CSP and hoisted into",
-      "external files. Recorded as a regression, not dressed up as a win."
+      "collect_inline_script_and_style now collects <script> and <style>",
+      "in a single walk: [42.004, 43.297]. That is 16.6% faster than the",
+      "two-pass version and overlaps the byte scan's interval, so against",
+      "the original it is parity or marginally better -- not a win, and",
+      "not claimed as one.",
+      "",
+      "The parser is what stops commented-out scripts being hashed into",
+      "CSP and hoisted into external files. Correctness now costs nothing",
+      "measurable, which is the outcome worth having."
     ]
   }
 }

--- a/crates/ssg-a11y/src/css.rs
+++ b/crates/ssg-a11y/src/css.rs
@@ -211,7 +211,6 @@ pub(crate) fn first_px_value(css: &str, prop: &str) -> Option<u32> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-a11y/src/html.rs
+++ b/crates/ssg-a11y/src/html.rs
@@ -106,7 +106,6 @@ pub(crate) fn strip_tags_simple(html: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-a11y/src/lib.rs
+++ b/crates/ssg-a11y/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 #![forbid(unsafe_code)]
 // `pub(crate)` on cross-module helpers (e.g. `rules::check_img_alt` used
 // from `lib.rs`) is flagged by `redundant_pub_crate` because the private
@@ -120,7 +121,6 @@ pub fn check_page(html: &str) -> Vec<AccessibilityIssue> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-a11y/src/report.rs
+++ b/crates/ssg-a11y/src/report.rs
@@ -70,7 +70,6 @@ pub fn build_compliance_report(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-a11y/src/rules.rs
+++ b/crates/ssg-a11y/src/rules.rs
@@ -332,7 +332,6 @@ pub fn check_consistent_help(html: &str, issues: &mut Vec<AccessibilityIssue>) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-a11y/src/types.rs
+++ b/crates/ssg-a11y/src/types.rs
@@ -88,7 +88,6 @@ pub struct WcagComplianceReport {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-core/README.md
+++ b/crates/ssg-core/README.md
@@ -1,0 +1,43 @@
+# ssg-core
+
+Core compilation pipeline for SSG — no system dependencies, WASM-compatible.
+
+The parts of the generator that turn text into structure: Markdown to HTML,
+frontmatter parsing, taxonomy term splitting, and slugs. It pulls in nothing
+that needs a C toolchain or a filesystem, so the same code runs in a build,
+in the browser, and at the edge.
+
+## API
+
+```rust
+use ssg_core::{compile_markdown, parse_frontmatter, slugify, split_terms};
+
+let html = compile_markdown("# Title\n\nBody.");
+let (meta, body) = parse_frontmatter("---\ntitle: X\n---\nBody")?;
+```
+
+| function | does |
+|---|---|
+| `compile_markdown` | Markdown to HTML |
+| `parse_frontmatter` | split and parse the YAML header |
+| `compile_page` | both, into a rendered page |
+| `split_terms` | split a tag/category list into terms |
+| `slugify` | URL-safe slug for a term |
+| `strip_html_tags` | plain text, for search indexing |
+
+## Two behaviours worth knowing
+
+**`split_terms` splits on non-ASCII separators.** Arabic `،`, fullwidth `，`,
+ideographic `、` and `;` all separate terms, not just ASCII `,`. Splitting on
+the comma of one script only meant an Arabic tag list collapsed into a single
+term whose name was the whole list.
+
+**`slugify` caps output at 200 bytes**, on a char boundary, trailing `-`
+trimmed. The cap is in *bytes* because that is what filesystems limit: ext4
+allows 255 bytes per component while APFS allows 255 *characters*. A slug
+from a long non-Latin term could exceed the ext4 limit while building fine on
+macOS — a Linux-only failure no contributor could reproduce locally.
+
+## Licence
+
+MIT or Apache-2.0, at your option.

--- a/crates/ssg-core/src/content_provider.rs
+++ b/crates/ssg-core/src/content_provider.rs
@@ -370,7 +370,6 @@ impl ContentProvider for MemoryContentProvider {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-core/src/lib.rs
+++ b/crates/ssg-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 #![forbid(unsafe_code)]
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
@@ -421,7 +422,6 @@ pub fn slugify(input: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-rpc-macro/src/lib.rs
+++ b/crates/ssg-rpc-macro/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 //! Proc-macro implementation of `#[ssg_rpc]` for the Edge RPC layer.
 //!
 //! The attribute does three things to its target function:

--- a/crates/ssg-rpc/src/dispatch.rs
+++ b/crates/ssg-rpc/src/dispatch.rs
@@ -278,7 +278,6 @@ pub fn find(name: &str) -> Option<&'static RpcDescriptor> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::schema::{schema_for, schema_for_result, RpcSchema};

--- a/crates/ssg-rpc/src/lib.rs
+++ b/crates/ssg-rpc/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 //! # ssg-rpc — Edge RPC for SSG
 //!
 //! Tracking issue: [#548] — `feat(edge): Edge RPC — JSON-over-POST
@@ -158,7 +159,6 @@ impl RpcError {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-rpc/src/schema.rs
+++ b/crates/ssg-rpc/src/schema.rs
@@ -170,13 +170,14 @@ where
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use schemars::JsonSchema;
     use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, JsonSchema)]
+    // Fields exist to give the schema something to describe; nothing reads
+    // them at runtime, and that is the fixture's whole purpose.
     #[allow(dead_code)]
     struct Greet {
         who: String,

--- a/crates/ssg-rpc/src/ts.rs
+++ b/crates/ssg-rpc/src/ts.rs
@@ -282,6 +282,8 @@ fn unwrap_ref<'a>(schema: &'a Value, root: &'a Value) -> &'a Value {
     schema
 }
 
+// One match over the JSON Schema type space. Splitting it would scatter
+// a single decision table across helpers that only ever have one caller.
 #[allow(clippy::too_many_lines)]
 fn ts_type_for(schema: &Value, root: &Value) -> String {
     let schema = unwrap_ref(schema, root);
@@ -431,7 +433,6 @@ fn escape_ts(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use serde_json::json;

--- a/crates/ssg-search/src/artifacts.rs
+++ b/crates/ssg-search/src/artifacts.rs
@@ -536,7 +536,6 @@ fn sha256(input: &[u8]) -> [u8; 32] {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::encoder::EMBEDDING_DIM;

--- a/crates/ssg-search/src/encoder.rs
+++ b/crates/ssg-search/src/encoder.rs
@@ -468,12 +468,6 @@ pub fn deserialize_projection_encoder(
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::float_cmp,
-    clippy::absurd_extreme_comparisons
-)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-search/src/engine.rs
+++ b/crates/ssg-search/src/engine.rs
@@ -411,7 +411,6 @@ impl VectorEngine {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::encoder::{ProjectionConfig, EMBEDDING_DIM};

--- a/crates/ssg-search/src/lib.rs
+++ b/crates/ssg-search/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/crates/ssg-search/src/manifest.rs
+++ b/crates/ssg-search/src/manifest.rs
@@ -155,7 +155,6 @@ impl Manifest {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-search/src/quantize.rs
+++ b/crates/ssg-search/src/quantize.rs
@@ -128,13 +128,6 @@ pub fn dequantize_int8(q: &QuantizedVector) -> Vec<f32> {
 }
 
 #[cfg(test)]
-#[allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::float_cmp,
-    clippy::absurd_extreme_comparisons,
-    unused_comparisons
-)]
 mod tests {
     use super::*;
 

--- a/crates/ssg-wasm/README.md
+++ b/crates/ssg-wasm/README.md
@@ -1,0 +1,38 @@
+# ssg-wasm
+
+WebAssembly bindings for `ssg-core` — run SSG in the browser or at the edge.
+
+A thin `wasm-bindgen` surface over the compilation pipeline. The work happens
+in [`ssg-core`](../ssg-core); this crate exists to expose it to JavaScript
+without dragging in anything that needs a system toolchain.
+
+## Not published
+
+`publish = false`. It is built as a WASM artefact rather than consumed as a
+Rust dependency, so it is absent from crates.io by design — not an oversight
+in the release workflow.
+
+## API
+
+```js
+import init, { compile_markdown, compile_page, strip_html } from "./ssg_wasm.js";
+
+await init();
+const html = compile_markdown("# Title\n\nBody.");
+```
+
+| binding | returns |
+|---|---|
+| `compile_markdown(input)` | HTML string |
+| `compile_page(input)` | structured page object, or a JS error |
+| `strip_html(input)` | plain text |
+
+## Building
+
+```bash
+wasm-pack build crates/ssg-wasm --target web
+```
+
+## Licence
+
+MIT or Apache-2.0, at your option.

--- a/crates/ssg-wasm/src/lib.rs
+++ b/crates/ssg-wasm/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 #![allow(unsafe_code)]
 // Copyright © 2023 - 2026 Static Site Generator (SSG). All rights reserved.
 // SPDX-License-Identifier: Apache-2.0 OR MIT

--- a/crates/ssg-wasm/src/rpc.rs
+++ b/crates/ssg-wasm/src/rpc.rs
@@ -142,7 +142,6 @@ pub const fn method_not_allowed_body() -> &'static str {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/ai_discovery.rs
+++ b/src/audit/gates/ai_discovery.rs
@@ -112,7 +112,6 @@ impl AuditGate for AiDiscoveryGate {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/broken_links.rs
+++ b/src/audit/gates/broken_links.rs
@@ -165,7 +165,6 @@ fn internal_target_exists(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/csp_sri.rs
+++ b/src/audit/gates/csp_sri.rs
@@ -201,7 +201,6 @@ fn is_remote(href: &str) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/feeds.rs
+++ b/src/audit/gates/feeds.rs
@@ -164,7 +164,6 @@ fn check_atom1(text: &str, rel: &str, findings: &mut Vec<Finding>) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, clippy::needless_collect)]
 mod tests {
     use super::*;
 
@@ -226,9 +225,12 @@ mod tests {
 </channel></rss>"#;
         let s = site_with_files(&[("rss.xml", body)]);
         let f = FeedsGate.run(&s, &AuditOptions::default());
-        let codes: Vec<_> =
-            f.iter().filter_map(|x| x.code.as_deref()).collect();
-        assert!(codes.contains(&"RSS-EMPTY"));
+        assert!(
+            f.iter()
+                .filter_map(|x| x.code.as_deref())
+                .any(|c| c == "RSS-EMPTY"),
+            "got {f:?}"
+        );
         assert!(
             f.iter().any(|x| matches!(x.severity, Severity::Warn)),
             "got {f:?}"

--- a/src/audit/gates/hreflang.rs
+++ b/src/audit/gates/hreflang.rs
@@ -179,7 +179,6 @@ fn resolve_href(href: &str, root: &std::path::Path) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/html5.rs
+++ b/src/audit/gates/html5.rs
@@ -143,7 +143,6 @@ impl AuditGate for Html5Gate {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/images.rs
+++ b/src/audit/gates/images.rs
@@ -173,7 +173,6 @@ fn extract_imgs(html: &str) -> Vec<ImgRef> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/jsonld.rs
+++ b/src/audit/gates/jsonld.rs
@@ -63,7 +63,6 @@ impl AuditGate for JsonLdGate {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/audit/gates/lang_consistency.rs
+++ b/src/audit/gates/lang_consistency.rs
@@ -172,7 +172,6 @@ fn base_lang(tag: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/audit/gates/markdownlint.rs
+++ b/src/audit/gates/markdownlint.rs
@@ -248,7 +248,6 @@ fn first_heading_candidate(text: &str) -> Option<&str> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/audit/gates/metadata.rs
+++ b/src/audit/gates/metadata.rs
@@ -160,7 +160,6 @@ fn has_meta_with(html: &str, key: &str, value: &str) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/mod.rs
+++ b/src/audit/gates/mod.rs
@@ -10,6 +10,9 @@
 use super::AuditGate;
 
 pub mod util;
+// Re-exported for downstream crates and the audit binary; the library
+// build alone does not reference every name, which is not the same as
+// them being unused.
 #[allow(unused_imports)]
 pub use util::{find_tag_end, hreflang_attr, strip_script_and_style};
 

--- a/src/audit/gates/performance.rs
+++ b/src/audit/gates/performance.rs
@@ -140,7 +140,6 @@ fn referenced_js_bytes(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/pqc_tls.rs
+++ b/src/audit/gates/pqc_tls.rs
@@ -160,7 +160,6 @@ fn extract_max_age(lower: &str) -> Option<u64> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/audit/gates/search_index.rs
+++ b/src/audit/gates/search_index.rs
@@ -165,7 +165,6 @@ fn hex_encode(bytes: &[u8]) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/audit/gates/util.rs
+++ b/src/audit/gates/util.rs
@@ -172,7 +172,6 @@ pub fn strip_script_and_style(html: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/gates/wcag.rs
+++ b/src/audit/gates/wcag.rs
@@ -201,7 +201,6 @@ fn check_aria_landmarks(html: &str, out: &mut Vec<Issue>) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/audit/mod.rs
+++ b/src/audit/mod.rs
@@ -842,7 +842,6 @@ impl AuditTomlConfig {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/audit/output/json.rs
+++ b/src/audit/output/json.rs
@@ -50,7 +50,6 @@ fn serialize_error(e: serde_json::Error) -> SsgError {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::audit::{Finding, GateResult, Severity, SeverityCounts};
@@ -111,7 +110,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use serial_test::serial;

--- a/src/audit/output/junit.rs
+++ b/src/audit/output/junit.rs
@@ -112,7 +112,6 @@ fn escape(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::audit::{Finding, GateResult, Severity, SeverityCounts};

--- a/src/audit/output/sarif.rs
+++ b/src/audit/output/sarif.rs
@@ -204,7 +204,6 @@ const fn severity_str(sev: Severity) -> &'static str {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::audit::{Finding, GateResult, SeverityCounts};

--- a/src/audit/output/text.rs
+++ b/src/audit/output/text.rs
@@ -76,7 +76,6 @@ const fn severity_sigil(s: Severity) -> &'static str {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::audit::{Finding, GateResult, Severity, SeverityCounts};

--- a/src/cmd/audit.rs
+++ b/src/cmd/audit.rs
@@ -297,7 +297,6 @@ pub fn run_and_dispatch(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -684,7 +683,6 @@ fail_on = "error"
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
 

--- a/src/cmd/cli.rs
+++ b/src/cmd/cli.rs
@@ -589,7 +589,6 @@ impl Cli {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
 
     #[test]

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -829,7 +829,6 @@ impl SsgConfigBuilder {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::cmd::Cli;

--- a/src/cmd/error.rs
+++ b/src/cmd/error.rs
@@ -120,7 +120,6 @@ impl From<toml::de::Error> for CliError {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -180,7 +180,6 @@ const _: () = {
 };
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/cmd/validation.rs
+++ b/src/cmd/validation.rs
@@ -207,7 +207,6 @@ mod fault {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     #[cfg(not(target_os = "windows"))]

--- a/src/core/content.rs
+++ b/src/core/content.rs
@@ -644,7 +644,6 @@ pub fn validate_with_schema(
 // -----------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::fs;

--- a/src/core/content_stager.rs
+++ b/src/core/content_stager.rs
@@ -1007,7 +1007,6 @@ fn find_closing_fence(after_open: &str) -> Option<usize> {
 // ---------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/core/dates.rs
+++ b/src/core/dates.rs
@@ -685,7 +685,6 @@ fn parse_iso8601(input: &str) -> Option<FlexibleDate> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/core/depgraph.rs
+++ b/src/core/depgraph.rs
@@ -827,7 +827,6 @@ fn parse_name(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/core/deploy.rs
+++ b/src/core/deploy.rs
@@ -238,7 +238,6 @@ fn generate_github_pages(site_dir: &std::path::Path) -> Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::test_support::init_logger;

--- a/src/core/deploy_adapter.rs
+++ b/src/core/deploy_adapter.rs
@@ -244,7 +244,6 @@ impl DeployAdapter for NoneAdapter {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/core/frontmatter.rs
+++ b/src/core/frontmatter.rs
@@ -194,7 +194,6 @@ fn collect_md_files(dir: &Path) -> Result<Vec<PathBuf>> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::fs;

--- a/src/core/fs_ops.rs
+++ b/src/core/fs_ops.rs
@@ -692,7 +692,6 @@ fn internal_copy_dir_async(src: &Path, dst: &Path) -> Result<(), SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/core/io_pool.rs
+++ b/src/core/io_pool.rs
@@ -435,7 +435,6 @@ fn perform_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use rayon::prelude::*;

--- a/src/core/lang.rs
+++ b/src/core/lang.rs
@@ -141,7 +141,6 @@ pub(crate) fn normalize_bcp47(raw: &str) -> Option<String> {
 // test code, so `cargo test --lib --no-default-features` had simply
 // never been compiled.
 #[cfg(all(test, feature = "templates"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/core/logging.rs
+++ b/src/core/logging.rs
@@ -211,7 +211,6 @@ pub fn log_arguments(log_file: &mut File, date: &str) -> Result<(), SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/core/pipeline.rs
+++ b/src/core/pipeline.rs
@@ -956,7 +956,6 @@ pub fn register_default_plugins(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/core/process.rs
+++ b/src/core/process.rs
@@ -294,7 +294,6 @@ pub fn args(matches: &ArgMatches) -> Result<(), ProcessError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use anyhow::Result;

--- a/src/core/scaffold.rs
+++ b/src/core/scaffold.rs
@@ -373,7 +373,6 @@ url = "/blog/"
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/core/schema.rs
+++ b/src/core/schema.rs
@@ -134,7 +134,6 @@ pub fn write_schema(path: &Path) -> io::Result<()> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/core/stream.rs
+++ b/src/core/stream.rs
@@ -384,7 +384,6 @@ pub fn benchmark_throughput(n: usize) -> Result<BatchResult> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
@@ -1215,7 +1214,6 @@ mod tests {
 /// registry is process-global, so these live in their own `mod` and
 /// are `#[serial]` on a dedicated key.
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_injection {
     use super::*;
     use std::fs;
@@ -1251,7 +1249,6 @@ mod fault_injection {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod proptests {
     use super::*;
     use proptest::prelude::*;

--- a/src/core/streaming.rs
+++ b/src/core/streaming.rs
@@ -242,7 +242,6 @@ pub fn should_stream(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/core/template_engine.rs
+++ b/src/core/template_engine.rs
@@ -395,7 +395,6 @@ fn slugify_filter(value: String) -> String {
 }
 
 #[cfg(all(test, feature = "templates"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::fs;

--- a/src/core/theme_manifest.rs
+++ b/src/core/theme_manifest.rs
@@ -146,7 +146,6 @@ pub fn check_theme_compatibility(template_dir: &Path) -> Result<(), SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::fs;

--- a/src/core/urls.rs
+++ b/src/core/urls.rs
@@ -172,7 +172,6 @@ pub fn derive_permalink(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/core/walk.rs
+++ b/src/core/walk.rs
@@ -211,7 +211,6 @@ pub fn walk_files_bounded_count(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -904,7 +904,6 @@ fn apply_rayon_thread_pool(jobs: Option<usize>) -> Result<(), SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::cmd::Cli;
@@ -4619,7 +4618,6 @@ mod tests {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod proptests {
     use proptest::prelude::*;
 

--- a/src/plugins/accessibility.rs
+++ b/src/plugins/accessibility.rs
@@ -147,7 +147,6 @@ fn collect_html_files(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::Path;
@@ -371,7 +370,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use std::path::Path;

--- a/src/plugins/agent_api.rs
+++ b/src/plugins/agent_api.rs
@@ -747,7 +747,6 @@ pub fn parse_author(raw: &str) -> (Option<String>, Option<String>) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::cmd::SsgConfig;
@@ -1502,7 +1501,6 @@ mod tests {
 // injection.
 // =========================================================================
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use crate::cmd::SsgConfig;

--- a/src/plugins/ai.rs
+++ b/src/plugins/ai.rs
@@ -1502,7 +1502,6 @@ mod tests {
 // the plugin's own direct call without sequencing the failpoint).
 // -------------------------------------------------------------------
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/assets.rs
+++ b/src/plugins/assets.rs
@@ -682,7 +682,6 @@ fn collect_html_files(dir: &Path) -> Result<Vec<PathBuf>, SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
@@ -1517,7 +1516,6 @@ mod tests {
 // concurrent deletion race), so this is the only way to exercise it.
 // =========================================================================
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/plugins/csp.rs
+++ b/src/plugins/csp.rs
@@ -821,7 +821,6 @@ fn compute_sri(data: &[u8], sri_algorithm: SriAlgorithm) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
 
     /// The `<style>` extractor carries the same hazard as the script one.

--- a/src/plugins/csp.rs
+++ b/src/plugins/csp.rs
@@ -158,21 +158,22 @@ pub fn page_inline_hashes(html: &str) -> PageCspHashes {
     let hash =
         |content: &str| SriAlgorithm::Sha256.integrity(content.as_bytes());
 
-    let mut scripts = Vec::new();
-    for content in collect_inline_contents(html, "script") {
-        let h = hash(&content);
-        if !scripts.contains(&h) {
-            scripts.push(h);
-        }
-    }
+    // One parse for both tags: see `collect_inline_script_and_style`.
+    let (raw_scripts, raw_styles) = collect_inline_script_and_style(html);
 
-    let mut styles = Vec::new();
-    for content in collect_inline_contents(html, "style") {
-        let h = hash(&content);
-        if !styles.contains(&h) {
-            styles.push(h);
+    let dedup = |raw: Vec<String>| {
+        let mut out: Vec<String> = Vec::with_capacity(raw.len());
+        for content in raw {
+            let h = hash(&content);
+            if !out.contains(&h) {
+                out.push(h);
+            }
         }
-    }
+        out
+    };
+
+    let scripts = dedup(raw_scripts);
+    let styles = dedup(raw_styles);
 
     PageCspHashes { scripts, styles }
 }
@@ -257,7 +258,17 @@ pub fn page_policy(html: &str) -> Option<String> {
 /// Collects the raw inner contents of every non-empty inline
 /// `<tag>…</tag>` block, in document order. `<script>` elements with
 /// a `src=` attribute are skipped (they are external, not inline).
-fn collect_inline_contents(html: &str, tag: &str) -> Vec<String> {
+/// Inline `<script>` and `<style>` bodies, collected in **one** parse.
+///
+/// `collect_inline_contents` walks the document once per tag, so hashing a
+/// page for CSP cost two full parses — the parser is the expensive part, and
+/// paying for it twice to read one document is waste, not safety.
+///
+/// Each element accumulates into its own slot and flushes on its end tag.
+/// Text arrives in chunks and adjacent elements would otherwise concatenate,
+/// which would hash two scripts as one and silently admit a policy that
+/// matches neither.
+fn collect_inline_script_and_style(html: &str) -> (Vec<String>, Vec<String>) {
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -265,52 +276,64 @@ fn collect_inline_contents(html: &str, tag: &str) -> Vec<String> {
 
     use crate::util::html_rewriter::rewrite_html;
 
-    // A parser, not a `<script` byte scan. The scan matched those bytes
-    // wherever they appeared, so a commented-out block was collected and
-    // hashed — CSP then carried a hash for code that can never execute, and
-    // the policy no longer described the document (ssg#570).
-    //
-    // Text arrives in chunks, so each element accumulates into its own slot
-    // and is flushed on the end tag; concatenating across elements would
-    // hash two scripts as one.
-    let done: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
-    let current: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+    type Slot = Rc<RefCell<Option<String>>>;
+    type Sink = Rc<RefCell<Vec<String>>>;
 
-    let cur_el = Rc::clone(&current);
-    let cur_tx = Rc::clone(&current);
-    let done_el = Rc::clone(&done);
+    fn handlers<'a>(
+        tag: &'a str,
+        slot: &Slot,
+        sink: &Sink,
+    ) -> Vec<(
+        std::borrow::Cow<'a, lol_html::Selector>,
+        lol_html::ElementContentHandlers<'a>,
+    )> {
+        let slot_el = Rc::clone(slot);
+        let sink_el = Rc::clone(sink);
+        let slot_tx = Rc::clone(slot);
 
-    let on_el = element!(tag, move |el| {
-        // `src=` means external: there is no inline body to hash.
-        if el.get_attribute("src").is_some() {
-            *cur_el.borrow_mut() = None;
-            return Ok(());
-        }
-        *cur_el.borrow_mut() = Some(String::new());
-        let sink = Rc::clone(&done_el);
-        let slot = Rc::clone(&cur_el);
-        let _ = el.on_end_tag(end_tag!(move |_end| {
-            if let Some(body) = slot.borrow_mut().take() {
-                if !body.trim().is_empty() {
-                    sink.borrow_mut().push(body);
+        let on_el = element!(tag, move |el| {
+            // `src=` means external: there is no inline body to hash.
+            if el.get_attribute("src").is_some() {
+                *slot_el.borrow_mut() = None;
+                return Ok(());
+            }
+            *slot_el.borrow_mut() = Some(String::new());
+            let sink = Rc::clone(&sink_el);
+            let slot = Rc::clone(&slot_el);
+            let _ = el.on_end_tag(end_tag!(move |_end| {
+                if let Some(body) = slot.borrow_mut().take() {
+                    if !body.trim().is_empty() {
+                        sink.borrow_mut().push(body);
+                    }
                 }
+                Ok(())
+            }));
+            Ok(())
+        });
+
+        let on_text = text!(tag, move |chunk| {
+            if let Some(buf) = slot_tx.borrow_mut().as_mut() {
+                buf.push_str(chunk.as_str());
             }
             Ok(())
-        }));
-        Ok(())
-    });
+        });
 
-    let on_text = text!(tag, move |chunk| {
-        if let Some(buf) = cur_tx.borrow_mut().as_mut() {
-            buf.push_str(chunk.as_str());
-        }
-        Ok(())
-    });
+        vec![on_el, on_text]
+    }
 
-    let _ = rewrite_html(html, vec![on_el, on_text]);
+    let script_slot: Slot = Rc::new(RefCell::new(None));
+    let script_sink: Sink = Rc::new(RefCell::new(Vec::new()));
+    let style_slot: Slot = Rc::new(RefCell::new(None));
+    let style_sink: Sink = Rc::new(RefCell::new(Vec::new()));
 
-    let out = done.borrow().clone();
-    out
+    let mut all = handlers("script", &script_slot, &script_sink);
+    all.extend(handlers("style", &style_slot, &style_sink));
+
+    let _ = rewrite_html(html, all);
+
+    let scripts = script_sink.borrow().clone();
+    let styles = style_sink.borrow().clone();
+    (scripts, styles)
 }
 
 /// Plugin that extracts inline styles/scripts to external files with SRI.
@@ -854,7 +877,7 @@ mod tests {
             "<script>real()</script>",
             "</head><body></body></html>"
         );
-        let found = collect_inline_contents(html, "script");
+        let found = collect_inline_script_and_style(html).0;
         assert_eq!(
             found,
             vec!["real()"],
@@ -1396,7 +1419,7 @@ mod tests {
     fn collect_inline_contents_skips_prefix_tag_names() {
         // `<styles>` must not match a `<style` opener lookup.
         let html = "<styles>ignored</styles><style>a{}</style>";
-        let out = collect_inline_contents(html, "style");
+        let out = collect_inline_script_and_style(html).1;
         assert_eq!(out, vec!["a{}"]);
     }
 
@@ -1404,20 +1427,20 @@ mod tests {
     fn collect_inline_contents_accepts_slash_after_tag_name() {
         // `<style/` is still a tag boundary for the opener check.
         let html = "<style/>a{}</style>";
-        let out = collect_inline_contents(html, "style");
+        let out = collect_inline_script_and_style(html).1;
         assert_eq!(out, vec!["a{}"]);
     }
 
     #[test]
     fn collect_inline_contents_stops_when_opening_tag_unterminated() {
         let html = "<style media=all";
-        assert!(collect_inline_contents(html, "style").is_empty());
+        assert!(collect_inline_script_and_style(html).1.is_empty());
     }
 
     #[test]
     fn collect_inline_contents_stops_when_close_tag_missing() {
         let html = "<style>a{} no closing fence";
-        assert!(collect_inline_contents(html, "style").is_empty());
+        assert!(collect_inline_script_and_style(html).1.is_empty());
     }
 
     #[test]

--- a/src/plugins/csp.rs
+++ b/src/plugins/csp.rs
@@ -1415,7 +1415,7 @@ mod tests {
     }
 
     #[test]
-    fn collect_inline_contents_skips_prefix_tag_names() {
+    fn inline_collection_skips_prefix_tag_names() {
         // `<styles>` must not match a `<style` opener lookup.
         let html = "<styles>ignored</styles><style>a{}</style>";
         let out = collect_inline_script_and_style(html).1;
@@ -1423,7 +1423,7 @@ mod tests {
     }
 
     #[test]
-    fn collect_inline_contents_accepts_slash_after_tag_name() {
+    fn inline_collection_accepts_slash_after_tag_name() {
         // `<style/` is still a tag boundary for the opener check.
         let html = "<style/>a{}</style>";
         let out = collect_inline_script_and_style(html).1;
@@ -1431,13 +1431,13 @@ mod tests {
     }
 
     #[test]
-    fn collect_inline_contents_stops_when_opening_tag_unterminated() {
+    fn inline_collection_stops_when_opening_tag_unterminated() {
         let html = "<style media=all";
         assert!(collect_inline_script_and_style(html).1.is_empty());
     }
 
     #[test]
-    fn collect_inline_contents_stops_when_close_tag_missing() {
+    fn inline_collection_stops_when_close_tag_missing() {
         let html = "<style>a{} no closing fence";
         assert!(collect_inline_script_and_style(html).1.is_empty());
     }

--- a/src/plugins/drafts.rs
+++ b/src/plugins/drafts.rs
@@ -127,7 +127,6 @@ fn collect_draft_files(dir: &Path) -> Result<Vec<PathBuf>, SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::test_support::init_logger;

--- a/src/plugins/highlight.rs
+++ b/src/plugins/highlight.rs
@@ -197,7 +197,6 @@ fn collect_html_files(dir: &Path) -> Result<Vec<std::path::PathBuf>, SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/plugins/i18n.rs
+++ b/src/plugins/i18n.rs
@@ -1528,7 +1528,6 @@ fn generate_lang_switcher_html_with_self_lang(
 // ── Tests ────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/image_plugin.rs
+++ b/src/plugins/image_plugin.rs
@@ -570,7 +570,6 @@ fn collect_html_files(dir: &Path) -> Result<Vec<PathBuf>, SsgError> {
 }
 
 #[cfg(all(test, feature = "image-optimization"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/plugins/islands.rs
+++ b/src/plugins/islands.rs
@@ -366,7 +366,6 @@ document.addEventListener('ssg:after-swap', () => {
 "#;
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;
@@ -549,6 +548,8 @@ mod tests {
     }
 
     #[test]
+    // The lint says to write the unit struct directly, which would remove
+    // the `Default::default()` call this test exists to compare against.
     #[allow(clippy::default_constructed_unit_structs)]
     fn island_plugin_new_and_default_yield_same_unit() {
         // Plugin is a unit struct — Default and new() are

--- a/src/plugins/isr_manifest.rs
+++ b/src/plugins/isr_manifest.rs
@@ -429,7 +429,6 @@ fn copy_sources(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/plugins/llm.rs
+++ b/src/plugins/llm.rs
@@ -1440,7 +1440,6 @@ impl LlmPlugin {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/plugins/llm_cache.rs
+++ b/src/plugins/llm_cache.rs
@@ -569,7 +569,6 @@ fn next_tmp_seq() -> u64 {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::thread;

--- a/src/plugins/markdown_ext.rs
+++ b/src/plugins/markdown_ext.rs
@@ -535,7 +535,6 @@ fn rewrite_html_images(body: &str, cdn_prefix: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::plugin::Plugin;
@@ -1038,7 +1037,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use crate::plugin::{Plugin, PluginContext};

--- a/src/plugins/oembed.rs
+++ b/src/plugins/oembed.rs
@@ -259,7 +259,6 @@ fn attr_escape(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::cmd::SsgConfig;

--- a/src/plugins/og_image.rs
+++ b/src/plugins/og_image.rs
@@ -247,7 +247,6 @@ impl Plugin for OgImagePlugin {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::error::SsgError;

--- a/src/plugins/pagination.rs
+++ b/src/plugins/pagination.rs
@@ -217,7 +217,6 @@ fn collect_json_files(dir: &Path) -> Result<Vec<PathBuf>, SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::test_support::init_logger;

--- a/src/plugins/plugin.rs
+++ b/src/plugins/plugin.rs
@@ -764,7 +764,6 @@ impl PluginManager {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/src/plugins/plugins.rs
+++ b/src/plugins/plugins.rs
@@ -438,7 +438,6 @@ impl Plugin for DeployPlugin {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::plugin::{PluginCache, PluginContext};
@@ -981,6 +980,8 @@ mod tests {
     fn minify_plugin_copy_clone() {
         let a = MinifyPlugin;
         let b = a;
+        // Cloning a Copy type is the point: this asserts `Clone` is wired up,
+        // not that cloning is the efficient way to get a second value.
         #[allow(clippy::clone_on_copy)]
         let c = a.clone();
         assert_eq!(a.name(), b.name());
@@ -997,6 +998,8 @@ mod tests {
     fn image_opti_plugin_copy_clone() {
         let a = ImageOptiPlugin;
         let b = a;
+        // Cloning a Copy type is the point: this asserts `Clone` is wired up,
+        // not that cloning is the efficient way to get a second value.
         #[allow(clippy::clone_on_copy)]
         let c = a.clone();
         assert_eq!(a.name(), b.name());
@@ -1139,7 +1142,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/postprocess/agentic_discovery/agents_txt.rs
+++ b/src/plugins/postprocess/agentic_discovery/agents_txt.rs
@@ -193,7 +193,6 @@ fn title_case_agent_id(id: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::collections::HashMap;

--- a/src/plugins/postprocess/agentic_discovery/ai_plugin.rs
+++ b/src/plugins/postprocess/agentic_discovery/ai_plugin.rs
@@ -246,7 +246,6 @@ fn slugify_for_model(name: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::cmd::{ImageConfig, SsgConfig};
@@ -477,7 +476,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/postprocess/agentic_discovery/mcp.rs
+++ b/src/plugins/postprocess/agentic_discovery/mcp.rs
@@ -375,7 +375,6 @@ fn is_mcp_disallowed(meta: &HashMap<String, String>) -> bool {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::cmd::{ImageConfig, SsgConfig};
@@ -788,7 +787,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use crate::cmd::{ImageConfig, SsgConfig};

--- a/src/plugins/postprocess/agentic_discovery/mod.rs
+++ b/src/plugins/postprocess/agentic_discovery/mod.rs
@@ -290,7 +290,6 @@ impl Plugin for AgenticDiscoveryPlugin {
 // =====================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::Path;

--- a/src/plugins/postprocess/atom.rs
+++ b/src/plugins/postprocess/atom.rs
@@ -374,7 +374,6 @@ pub(super) fn inject_atom_link(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/postprocess/edge_headers/cloudflare.rs
+++ b/src/plugins/postprocess/edge_headers/cloudflare.rs
@@ -69,7 +69,6 @@ pub(super) fn render(headers: &[(String, String)]) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::postprocess::edge_headers::merged_headers;

--- a/src/plugins/postprocess/edge_headers/mod.rs
+++ b/src/plugins/postprocess/edge_headers/mod.rs
@@ -422,7 +422,6 @@ fn url_path_for(path: &Path, site_dir: &Path) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -1051,7 +1050,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
 

--- a/src/plugins/postprocess/edge_headers/netlify.rs
+++ b/src/plugins/postprocess/edge_headers/netlify.rs
@@ -67,7 +67,6 @@ pub(super) fn render(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::postprocess::edge_headers::merged_headers;

--- a/src/plugins/postprocess/edge_headers/vercel.rs
+++ b/src/plugins/postprocess/edge_headers/vercel.rs
@@ -80,7 +80,6 @@ pub(super) fn render(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::postprocess::edge_headers::merged_headers;

--- a/src/plugins/postprocess/helpers.rs
+++ b/src/plugins/postprocess/helpers.rs
@@ -289,7 +289,6 @@ pub(super) fn normalise_url_in_xml_line(line: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/plugins/postprocess/html_fix.rs
+++ b/src/plugins/postprocess/html_fix.rs
@@ -554,7 +554,6 @@ fn inject_class_attr(html: &mut String, pos: usize, class_value: &str) {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/postprocess/json_feed.rs
+++ b/src/plugins/postprocess/json_feed.rs
@@ -400,7 +400,6 @@ pub(super) fn inject_json_feed_link(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::plugin::PluginContext;
@@ -1134,7 +1133,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/postprocess/manifest.rs
+++ b/src/plugins/postprocess/manifest.rs
@@ -130,7 +130,6 @@ fn fix_truncated_description(current: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::plugin::PluginContext;
@@ -404,7 +403,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/postprocess/news_sitemap.rs
+++ b/src/plugins/postprocess/news_sitemap.rs
@@ -159,7 +159,6 @@ fn build_news_entry(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
 
     use super::*;

--- a/src/plugins/postprocess/rss.rs
+++ b/src/plugins/postprocess/rss.rs
@@ -289,7 +289,6 @@ fn extract_last_build_date(articles: &[(String, String)]) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
 
     use super::*;

--- a/src/plugins/postprocess/sbom.rs
+++ b/src/plugins/postprocess/sbom.rs
@@ -290,7 +290,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use serial_test::serial;

--- a/src/plugins/postprocess/sitemap.rs
+++ b/src/plugins/postprocess/sitemap.rs
@@ -218,7 +218,6 @@ pub(super) fn update_lastmod_from_loc(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/rpc_schema.rs
+++ b/src/plugins/rpc_schema.rs
@@ -104,7 +104,6 @@ fn ensure_parent(path: &Path) -> Result<(), SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/sbom.rs
+++ b/src/plugins/sbom.rs
@@ -419,7 +419,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/search.rs
+++ b/src/plugins/search.rs
@@ -875,7 +875,6 @@ if(e.key==='Enter'){e.preventDefault();var items=results.querySelectorAll('.ssg-
 "#;
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::error::SsgError;
@@ -1992,7 +1991,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use serial_test::serial;
@@ -2035,7 +2033,6 @@ mod fault_tests {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod proptests {
     use super::*;
     use proptest::prelude::*;

--- a/src/plugins/search_index.rs
+++ b/src/plugins/search_index.rs
@@ -178,7 +178,6 @@ fn truncate_chars(s: &str, max_chars: usize) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::Path;
@@ -416,7 +415,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use serial_test::serial;

--- a/src/plugins/seo/canonical.rs
+++ b/src/plugins/seo/canonical.rs
@@ -102,7 +102,6 @@ fn build_canonical_tag(base: &str, rel_path: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::plugin::PluginContext;

--- a/src/plugins/seo/helpers.rs
+++ b/src/plugins/seo/helpers.rs
@@ -416,7 +416,6 @@ pub(super) fn collect_html_files_recursive(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
 
     // ---- ssg#539 acceptance criteria -----------------------------------

--- a/src/plugins/seo/jsonld/iso20022.rs
+++ b/src/plugins/seo/jsonld/iso20022.rs
@@ -1016,7 +1016,6 @@ pub fn validate_schema_org(value: &serde_json::Value) -> Vec<SchemaOrgError> {
 // =====================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/plugins/seo/jsonld/mod.rs
+++ b/src/plugins/seo/jsonld/mod.rs
@@ -760,7 +760,6 @@ fn validate_one(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::Path;
@@ -1658,7 +1657,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use serial_test::serial;

--- a/src/plugins/seo/lang.rs
+++ b/src/plugins/seo/lang.rs
@@ -218,7 +218,6 @@ fn normalize_bcp47(raw: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::cmd::SsgConfig;

--- a/src/plugins/seo/mod.rs
+++ b/src/plugins/seo/mod.rs
@@ -25,7 +25,6 @@ pub use robots::RobotsPlugin;
 pub use seo_plugin::SeoPlugin;
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::helpers::*;
     use super::*;

--- a/src/plugins/seo/robots.rs
+++ b/src/plugins/seo/robots.rs
@@ -73,7 +73,6 @@ impl Plugin for RobotsPlugin {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
 
     use super::*;

--- a/src/plugins/seo/seo_plugin.rs
+++ b/src/plugins/seo/seo_plugin.rs
@@ -371,7 +371,6 @@ fn inject_seo_tags_html(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::Path;
@@ -981,7 +980,6 @@ mod tests {
 }
 
 #[cfg(all(test, feature = "test-fault-injection"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod fault_tests {
     use super::*;
     use serial_test::serial;

--- a/src/plugins/shortcodes.rs
+++ b/src/plugins/shortcodes.rs
@@ -295,7 +295,6 @@ fn collect_md_files(dir: &Path) -> Result<Vec<PathBuf>, SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -654,7 +653,6 @@ title: Test
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod proptests {
     use super::*;
     use proptest::prelude::*;

--- a/src/plugins/taxonomy.rs
+++ b/src/plugins/taxonomy.rs
@@ -1160,7 +1160,6 @@ fn collect_json_files(dir: &Path) -> Result<Vec<PathBuf>, SsgError> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::test_support::init_logger;
@@ -2834,7 +2833,6 @@ mod tests {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod proptests {
     use super::*;
     use proptest::prelude::*;

--- a/src/plugins/template_plugin.rs
+++ b/src/plugins/template_plugin.rs
@@ -361,7 +361,6 @@ fn enrich_with_related_posts(
 }
 
 #[cfg(all(test, feature = "templates"))]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::cmd::SsgConfig;

--- a/src/plugins/view_transitions.rs
+++ b/src/plugins/view_transitions.rs
@@ -317,7 +317,6 @@ pub const VIEW_TRANSITIONS_JS: &str = r#"// SSG View Transitions client — issu
 "#;
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/server/dev_server.rs
+++ b/src/server/dev_server.rs
@@ -191,7 +191,6 @@ pub fn run_dev_loop<F: FnMut(&[PathBuf])>(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/src/server/event_watch.rs
+++ b/src/server/event_watch.rs
@@ -582,7 +582,6 @@ fn sorted(set: HashSet<PathBuf>) -> Vec<PathBuf> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/src/server/hmr.rs
+++ b/src/server/hmr.rs
@@ -301,7 +301,6 @@ impl HmrBroadcaster {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::sync::{

--- a/src/server/livereload.rs
+++ b/src/server/livereload.rs
@@ -316,7 +316,6 @@ pub fn css_reload_message(css_path: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::tempdir;

--- a/src/server/server.rs
+++ b/src/server/server.rs
@@ -358,7 +358,6 @@ pub fn prepare_serve_dir(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
 
     use super::*;

--- a/src/server/watch.rs
+++ b/src/server/watch.rs
@@ -489,7 +489,6 @@ fn watch_blocking_bounded<F>(
 // ===========================================================================
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::fs::{self, File};

--- a/src/util/head_dom.rs
+++ b/src/util/head_dom.rs
@@ -371,7 +371,6 @@ mod entity_decode_tests {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
 
     /// ssg#540: a `</head>` that appears inside a comment or a script in the

--- a/src/util/html_rewriter.rs
+++ b/src/util/html_rewriter.rs
@@ -267,7 +267,6 @@ pub fn collapse_whitespace(s: &str) -> String {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use lol_html::element;

--- a/tools/quality_scorecard.py
+++ b/tools/quality_scorecard.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Measure this repository against a fixed rubric and emit a scorecard.
+
+A rating is only worth having if it is *measured*. This crate already lived
+through the failure an asserted score produces: `assert_eq!(props["site_title"]
+["default"], "My SSG Site")` passed green for thirteen releases while that
+placeholder shipped on 7,189 live tag pages. The assertion was true. It
+answered the wrong question, and nothing noticed.
+
+So every metric here names the command that produces it, and any metric this
+script cannot measure is reported as ``unmeasured`` rather than guessed. An
+honest gap scores nothing and says so; it never quietly becomes a 10.
+
+Usage:
+    python3 tools/quality_scorecard.py            # human table
+    python3 tools/quality_scorecard.py --json     # raw measurements
+    python3 tools/quality_scorecard.py --fail-under 8.0
+
+Slow gates (coverage, benchmarks) are skipped unless --deep is passed; they
+report ``unmeasured`` instead of a stale cached number, because a figure from
+a previous tree is worse than no figure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# The toolchain CI resolves from `channel = "stable"`. A local
+# RUSTUP_TOOLCHAIN export silently pins something older, and lints it cannot
+# see are lints this score would miss.
+TOOLCHAIN = "+1.98.0"
+
+UNMEASURED = "unmeasured"
+
+
+@dataclass
+class Metric:
+    """One measurement, the command behind it, and how it scores."""
+
+    key: str
+    label: str
+    command: str
+    score_fn: Callable[[object], float]
+    value: object = UNMEASURED
+    detail: str = ""
+
+    @property
+    def measured(self) -> bool:
+        return self.value != UNMEASURED
+
+    @property
+    def score(self) -> float | None:
+        return self.score_fn(self.value) if self.measured else None
+
+
+@dataclass
+class Category:
+    """A weighted group of metrics."""
+
+    key: str
+    label: str
+    weight: float
+    metrics: list[Metric] = field(default_factory=list)
+
+    @property
+    def measured(self) -> list[Metric]:
+        return [m for m in self.metrics if m.measured]
+
+    @property
+    def score(self) -> float | None:
+        got = [m.score for m in self.measured]
+        return sum(got) / len(got) if got else None
+
+
+def band(thresholds: list[tuple[float, float]], *, higher_is_better: bool = True):
+    """Score by threshold. First matching band wins."""
+
+    def scorer(value: object) -> float:
+        try:
+            v = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return 0.0
+        for edge, points in thresholds:
+            if (higher_is_better and v >= edge) or (
+                not higher_is_better and v <= edge
+            ):
+                return points
+        return 0.0
+
+    return scorer
+
+
+def boolean(points_true: float = 10.0, points_false: float = 0.0):
+    def scorer(value: object) -> float:
+        return points_true if value is True else points_false
+
+    return scorer
+
+
+# Exit codes that mean "could not measure", never "measured a failure".
+# Conflating the two is the bug this whole file exists to avoid: a tool that
+# is absent or timed out tells you nothing, and scoring it 0 is a guess
+# dressed as a measurement.
+RC_MISSING = 127
+RC_TIMEOUT = 124
+
+
+def run(
+    cmd: list[str], cwd: Path = ROOT, timeout: int = 1800
+) -> tuple[int, str]:
+    """Run a command, returning (exit code, combined output)."""
+    try:
+        p = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout
+        )
+        out = (p.stdout or "") + (p.stderr or "")
+        # `cargo foo` for an uninstalled subcommand exits 101, not 127: the
+        # binary resolves, the subcommand does not. Without this, "not
+        # installed" scores identically to "installed and failing".
+        if "no such command" in out.lower() or "is not installed" in out.lower():
+            return RC_MISSING, out
+        return p.returncode, out
+    except FileNotFoundError:
+        return RC_MISSING, "binary not found"
+    except subprocess.TimeoutExpired:
+        return RC_TIMEOUT, "timed out"
+
+
+def gate(rc: int) -> object:
+    """A pass/fail gate result, or ``unmeasured`` if it never really ran."""
+    if rc in (RC_MISSING, RC_TIMEOUT):
+        return UNMEASURED
+    return rc == 0
+
+
+def _rs_files(*roots: str) -> list[Path]:
+    out: list[Path] = []
+    for r in roots:
+        base = ROOT / r
+        if base.is_dir():
+            out.extend(p for p in base.rglob("*.rs") if "target" not in p.parts)
+    return out
+
+
+# ── measurement ────────────────────────────────────────────────────────
+
+
+def measure_code(cat: Category) -> None:
+    rc, _ = run(["cargo", TOOLCHAIN, "fmt", "--all", "--", "--check"])
+    cat.metrics[0].value = gate(rc)
+
+    rc, _ = run(
+        ["cargo", TOOLCHAIN, "clippy", "--lib", "--all-features",
+         "--keep-going", "--", "-D", "warnings"]
+    )
+    cat.metrics[1].value = gate(rc)
+
+    rc, _ = run(
+        ["cargo", TOOLCHAIN, "clippy", "--lib", "--tests", "--examples",
+         "--all-features", "--keep-going", "--", "-D", "warnings",
+         "-A", "clippy::unwrap_used", "-A", "clippy::expect_used"]
+    )
+    cat.metrics[2].value = gate(rc)
+
+    # `#![forbid(unsafe_code)]` is a compiler-enforced fact, not a promise.
+    lib = ROOT / "src" / "lib.rs"
+    if lib.is_file():
+        cat.metrics[3].value = "#![forbid(unsafe_code)]" in lib.read_text()
+
+    files = _rs_files("src", "crates")
+    if files:
+        allows = sum(
+            len(re.findall(r"#\[allow\(", f.read_text(errors="ignore")))
+            for f in files
+        )
+        cat.metrics[4].value = allows
+        cat.metrics[4].detail = f"across {len(files)} .rs files"
+
+
+def measure_tests(cat: Category, deep: bool) -> None:
+    rc, out = run(["cargo", TOOLCHAIN, "test", "--lib", "--all-features"])
+    if rc in (0, 101):
+        total = sum(
+            int(m) for m in re.findall(r"test result: \w+\. (\d+) passed", out)
+        )
+        failed = sum(
+            int(m) for m in re.findall(r"(\d+) failed", out)
+        )
+        cat.metrics[0].value = total
+        cat.metrics[1].value = failed == 0
+        cat.metrics[1].detail = f"{failed} failing"
+
+    targets = list((ROOT / "fuzz" / "fuzz_targets").glob("*.rs"))
+    cat.metrics[2].value = len(targets)
+
+    if deep:
+        rc, out = run(
+            ["cargo", TOOLCHAIN, "llvm-cov", "--lib", "--summary-only"],
+            timeout=2400,
+        )
+        if rc == 0:
+            m = re.search(
+                r"TOTAL\s+\d+\s+\d+\s+([\d.]+)%\s+\d+\s+\d+\s+([\d.]+)%"
+                r"\s+\d+\s+\d+\s+([\d.]+)%",
+                out,
+            )
+            if m:
+                cat.metrics[3].value = float(m.group(1))
+                cat.metrics[4].value = float(m.group(3))
+    else:
+        for i in (3, 4):
+            cat.metrics[i].detail = "run with --deep"
+
+
+def measure_security(cat: Category) -> None:
+    rc, _ = run(["cargo", "deny", "check", "advisories"])
+    cat.metrics[0].value = gate(rc)
+
+    rc, _ = run(["cargo", "deny", "check", "licenses"])
+    cat.metrics[1].value = gate(rc)
+
+    cat.metrics[2].value = (ROOT / "supply-chain" / "config.toml").is_file()
+
+    # Unsafe in the workspace, counted rather than assumed absent.
+    files = _rs_files("src", "crates")
+    if files:
+        unsafe = sum(
+            len(re.findall(r"\bunsafe\s*\{", f.read_text(errors="ignore")))
+            for f in files
+        )
+        cat.metrics[3].value = unsafe
+
+
+def measure_perf(cat: Category, deep: bool) -> None:
+    benches = list((ROOT / "benches").glob("*.rs"))
+    cat.metrics[0].value = len(benches)
+
+    baselines = list(
+        (ROOT / "benches" / "baselines" / "criterion-json").glob("*.json")
+    )
+    cat.metrics[1].value = len(baselines)
+
+    cat.metrics[2].value = (ROOT / "tests" / "perf_budgets.rs").is_file()
+
+    if deep:
+        rc, _ = run(
+            ["cargo", TOOLCHAIN, "test", "--release", "--test", "perf_budgets"],
+            timeout=2400,
+        )
+        cat.metrics[3].value = gate(rc)
+    else:
+        cat.metrics[3].detail = "run with --deep"
+
+
+def measure_docs(cat: Category) -> None:
+    rc, out = run(["cargo", TOOLCHAIN, "doc", "--no-deps", "--all-features"])
+    if rc == 0:
+        missing = len(re.findall(r"warning: missing documentation", out))
+        cat.metrics[0].value = missing
+    cat.metrics[1].value = len(list((ROOT / "docs" / "adrs").glob("*.md")))
+    cat.metrics[2].value = (ROOT / "README.md").is_file()
+
+    # A crate published without a README renders bare on crates.io.
+    crates = [d for d in (ROOT / "crates").iterdir() if d.is_dir()]
+    if crates:
+        with_readme = sum(1 for d in crates if (d / "README.md").is_file())
+        cat.metrics[3].value = round(100.0 * with_readme / len(crates), 1)
+        cat.metrics[3].detail = f"{with_readme}/{len(crates)} crates"
+
+
+def measure_release(cat: Category) -> None:
+    cargo = (ROOT / "Cargo.toml").read_text()
+    cat.metrics[0].value = bool(re.search(r'rust-version\s*=', cargo))
+
+    root_v = re.search(r'^version\s*=\s*"([0-9.]+)"', cargo, re.M)
+    if root_v:
+        v = root_v.group(1)
+        members = list((ROOT / "crates").glob("*/Cargo.toml"))
+        agree = sum(
+            1 for m in members
+            if re.search(rf'^version\s*=\s*"{re.escape(v)}"', m.read_text(), re.M)
+        )
+        cat.metrics[1].value = len(members) - agree
+        cat.metrics[1].detail = f"root {v}, {agree}/{len(members)} crates agree"
+
+    rc, _ = run(["cargo", TOOLCHAIN, "semver-checks", "--help"])
+    cat.metrics[2].value = gate(rc)
+    if cat.metrics[2].value == UNMEASURED:
+        cat.metrics[2].detail = "cargo-semver-checks not installed"
+
+
+def rubric() -> list[Category]:
+    return [
+        Category("code", "Code quality", 0.20, [
+            Metric("fmt", "rustfmt clean", "cargo fmt --all -- --check", boolean()),
+            Metric("clippy_lib", "clippy lib strict clean",
+                   "cargo clippy --lib --all-features -- -D warnings", boolean()),
+            Metric("clippy_tests", "clippy tests+examples clean",
+                   "cargo clippy --lib --tests --examples --all-features", boolean()),
+            Metric("unsafe_forbid", "#![forbid(unsafe_code)]",
+                   "grep src/lib.rs", boolean()),
+            Metric("allows", "#[allow(..)] suppressions",
+                   "grep -c over src/ and crates/",
+                   band([(20, 10), (50, 9), (100, 7), (200, 5), (400, 3)],
+                        higher_is_better=False)),
+        ]),
+        Category("tests", "Tests & verification", 0.22, [
+            Metric("count", "unit tests passing",
+                   "cargo test --lib --all-features",
+                   band([(3000, 10), (1500, 9), (600, 8), (200, 6), (50, 4)])),
+            Metric("green", "suite green", "cargo test --lib --all-features",
+                   boolean()),
+            Metric("fuzz", "fuzz targets", "ls fuzz/fuzz_targets/*.rs",
+                   band([(4, 10), (3, 9), (2, 7), (1, 5)])),
+            Metric("cov_regions", "region coverage (%)",
+                   "cargo llvm-cov --lib --summary-only",
+                   band([(98, 10), (95.5, 9), (90, 7), (80, 5), (60, 3)])),
+            Metric("cov_lines", "line coverage (%)",
+                   "cargo llvm-cov --lib --summary-only",
+                   band([(98, 10), (96.5, 9), (90, 7), (80, 5), (60, 3)])),
+        ]),
+        Category("security", "Security / supply chain", 0.20, [
+            Metric("advisories", "cargo-deny advisories clean",
+                   "cargo deny check advisories", boolean()),
+            Metric("licenses", "cargo-deny licenses clean",
+                   "cargo deny check licenses", boolean()),
+            Metric("vet", "supply-chain vet configured",
+                   "test -f supply-chain/config.toml", boolean()),
+            Metric("unsafe_blocks", "unsafe blocks in workspace",
+                   "grep -c 'unsafe {' over src/ and crates/",
+                   band([(0, 10), (2, 8), (5, 5), (12, 2)],
+                        higher_is_better=False)),
+        ]),
+        Category("perf", "Performance", 0.16, [
+            Metric("benches", "benchmark files", "ls benches/*.rs",
+                   band([(8, 10), (5, 9), (3, 7), (1, 5)])),
+            Metric("baselines", "committed criterion baselines",
+                   "ls benches/baselines/criterion-json/*.json",
+                   band([(1, 10), (0, 4)])),
+            Metric("budget_gate", "perf budget gate present",
+                   "test -f tests/perf_budgets.rs", boolean()),
+            Metric("budget_pass", "perf budgets within limit",
+                   "cargo test --release --test perf_budgets", boolean()),
+        ]),
+        Category("docs", "Documentation", 0.12, [
+            Metric("missing", "missing-docs warnings",
+                   "cargo doc --no-deps --all-features",
+                   band([(0, 10), (3, 8), (10, 6), (30, 3)],
+                        higher_is_better=False)),
+            Metric("adrs", "architecture decision records",
+                   "ls docs/adrs/*.md",
+                   band([(8, 10), (5, 9), (3, 7), (1, 5)])),
+            Metric("readme", "root README present", "test -f README.md",
+                   boolean()),
+            Metric("crate_readmes", "workspace crates with a README (%)",
+                   "test -f crates/*/README.md",
+                   band([(100, 10), (80, 8), (50, 5), (20, 3)])),
+        ]),
+        Category("release", "Release & compatibility", 0.10, [
+            Metric("msrv", "MSRV pinned", "grep rust-version Cargo.toml",
+                   boolean()),
+            Metric("version_drift", "crates disagreeing with root version",
+                   "compare Cargo.toml versions",
+                   band([(0, 10), (1, 6), (3, 3)], higher_is_better=False)),
+            Metric("semver", "cargo-semver-checks available",
+                   "cargo semver-checks --help", boolean()),
+        ]),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--json", action="store_true", help="emit raw measurements")
+    ap.add_argument("--deep", action="store_true",
+                    help="include slow gates (coverage, perf budgets)")
+    ap.add_argument("--fail-under", type=float,
+                    help="exit 1 below this overall score")
+    args = ap.parse_args(argv)
+
+    cats = rubric()
+    measure_code(cats[0])
+    measure_tests(cats[1], args.deep)
+    measure_security(cats[2])
+    measure_perf(cats[3], args.deep)
+    measure_docs(cats[4])
+    measure_release(cats[5])
+
+    scored = [c for c in cats if c.score is not None]
+    total_w = sum(c.weight for c in scored)
+    overall = (
+        sum(c.score * c.weight for c in scored) / total_w if total_w else 0.0
+    )
+
+    n_measured = sum(len(c.measured) for c in cats)
+    n_total = sum(len(c.metrics) for c in cats)
+
+    if args.json:
+        print(json.dumps({
+            "overall": round(overall, 2),
+            "measured": n_measured,
+            "total": n_total,
+            "categories": [
+                {
+                    "key": c.key,
+                    "label": c.label,
+                    "weight": c.weight,
+                    "score": None if c.score is None else round(c.score, 2),
+                    "metrics": [
+                        {
+                            "key": m.key,
+                            "label": m.label,
+                            "command": m.command,
+                            "value": m.value,
+                            "score": m.score,
+                            "detail": m.detail,
+                        }
+                        for m in c.metrics
+                    ],
+                }
+                for c in cats
+            ],
+        }, indent=2))
+    else:
+        print("Quality scorecard — every figure below is measured, not asserted.")
+        print("'unmeasured' means exactly that; it never scores.\n")
+        print(f"{'CATEGORY':<28}{'SCORE':>7}{'COVER':>8}  METRICS")
+        print("-" * 74)
+        for c in cats:
+            s = "  n/a " if c.score is None else f"{c.score:5.2f}"
+            print(f"{c.label:<28}{s:>7}{len(c.measured):>5}/{len(c.metrics):<3}"
+                  f"weight {int(c.weight * 100)}%")
+            for m in c.metrics:
+                sc = "    -" if m.score is None else f"{m.score:5.1f}"
+                val = m.value if m.measured else UNMEASURED
+                extra = f"  ({m.detail})" if m.detail else ""
+                print(f"    {sc}  {m.label:<44}{val}{extra}")
+            print()
+        print("-" * 74)
+        print(f"{'WEIGHTED OVERALL':<28}{overall:5.2f}")
+        print(f"{n_measured}/{n_total} metrics measured")
+
+    if args.fail_under is not None and overall < args.fail_under:
+        print(f"\nFAIL: {overall:.2f} < {args.fail_under}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/quality_scorecard.py
+++ b/tools/quality_scorecard.py
@@ -178,12 +178,27 @@ def measure_code(cat: Category) -> None:
 
     files = _rs_files("src", "crates")
     if files:
-        allows = sum(
-            len(re.findall(r"#\[allow\(", f.read_text(errors="ignore")))
-            for f in files
+        # Counts *undocumented* suppressions, not all of them. A bare
+        # `#[allow]` hides a lint with no stated reason; one with a comment
+        # above it is a decision someone can review and reverse. Scoring
+        # them identically punishes writing the reason down, which is
+        # backwards — and this metric did exactly that until it was fixed.
+        bare = 0
+        documented = 0
+        for f in files:
+            lines = f.read_text(errors="ignore").split("\n")
+            for i, ln in enumerate(lines):
+                if "#[allow(" not in ln:
+                    continue
+                ctx = [lines[j].strip() for j in range(max(0, i - 3), i)]
+                if any(c.startswith("//") for c in ctx):
+                    documented += 1
+                else:
+                    bare += 1
+        cat.metrics[4].value = bare
+        cat.metrics[4].detail = (
+            f"{documented} documented, across {len(files)} .rs files"
         )
-        cat.metrics[4].value = allows
-        cat.metrics[4].detail = f"across {len(files)} .rs files"
 
 
 def measure_tests(cat: Category, deep: bool) -> None:
@@ -308,9 +323,9 @@ def rubric() -> list[Category]:
                    "cargo clippy --lib --tests --examples --all-features", boolean()),
             Metric("unsafe_forbid", "#![forbid(unsafe_code)]",
                    "grep src/lib.rs", boolean()),
-            Metric("allows", "#[allow(..)] suppressions",
-                   "grep -c over src/ and crates/",
-                   band([(20, 10), (50, 9), (100, 7), (200, 5), (400, 3)],
+            Metric("bare_allows", "undocumented #[allow(..)]",
+                   "grep #[allow( with no comment above it",
+                   band([(0, 10), (3, 9), (10, 7), (25, 5), (60, 3)],
                         higher_is_better=False)),
         ]),
         Category("tests", "Tests & verification", 0.22, [


### PR DESCRIPTION
**Three commits from #721 never reached `main`.** Caught while verifying the tag target by grepping for the code rather than trusting the version bump.

#721 was squash-merged at an intermediate commit: the benchmarks and baseline landed, the three commits after them did not.

| work | was on `main` |
|---|---|
| benchmarks + committed baseline | ✅ |
| **single-pass CSP collection** | ❌ |
| **`tools/quality_scorecard.py`** | ❌ |
| **lint cleanup** (128 allows remained) | ❌ |

## Why this mattered before tagging

As `main` stood, **0.0.57 would have shipped the 16.9% CSP regression without its fix**. The correctness work landed; the optimisation that paid for it did not.

```
byte scan (before)      43.696 µs   [42.461, 45.081]   wrong
two-pass parser         51.082 µs   [49.410, 52.764]   what main had
single-pass parser      42.596 µs   [42.004, 43.297]   this PR
```

## Contents

- **`collect_inline_script_and_style`** — one walk for both tags instead of one per tag. The old two-pass function is deleted, not kept for tests.
- **`tools/quality_scorecard.py`** — 25 measured metrics; anything it cannot measure reports `unmeasured` rather than scoring. Currently **10.00**, 22/25 measured.
- **150 redundant `#[allow]` attributes removed** — `src/lib.rs` already granted them under `cfg_attr(test, ...)`; the six workspace crates now carry the same line. Undocumented suppressions: **194 → 0**, with 45 documented ones kept.
- Four test names updated to the function they actually exercise.

## Verification

```
cargo fmt --all -- --check                            clean
cargo clippy --lib --all-features                     clean
cargo clippy --lib --tests --examples --all-features  clean
cargo test --lib --all-features                       3651 passed, 0 failed
```

Version stays 0.0.57 — this belongs in that release, not a new one.