### PR TITLE
build(deps): bump the oxc crates together to 0.148.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2813,13 +2813,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fce871c5cb07e557049ed27c8ca2aa530db797f73424c67e4bb8cfe61175e"
+checksum = "4721a6dea1ed51a31597a8865aac718c89ac6d6c91e1d67d1f632078a0518d97"
 dependencies = [
  "allocator-api2",
  "hashbrown 0.17.1",
- "oxc_data_structures 0.146.0",
+ "oxc_data_structures 0.148.0",
  "rustc-hash",
 ]
 
@@ -2842,20 +2842,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a999fd4494b604fc0328fc43443bc1298722500587d87d7e993118bd82c65d7b"
+checksum = "6b5c392641cfc4bd1a93881ee681f144d0213b1456288b2b6612f7eb8d2e02aa"
 dependencies = [
  "bitflags 2.13.1",
- "oxc_allocator 0.146.0",
- "oxc_ast_macros 0.146.0",
- "oxc_data_structures 0.146.0",
- "oxc_diagnostics 0.146.0",
- "oxc_estree 0.146.0",
- "oxc_regular_expression 0.146.0",
- "oxc_span 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast_macros 0.148.0",
+ "oxc_data_structures 0.148.0",
+ "oxc_diagnostics 0.148.0",
+ "oxc_estree 0.148.0",
+ "oxc_regular_expression 0.148.0",
+ "oxc_span 0.148.0",
  "oxc_str",
- "oxc_syntax 0.146.0",
+ "oxc_syntax 0.148.0",
 ]
 
 [[package]]
@@ -2872,9 +2872,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d715e3c300c95b1d797b05526567161fd86fcac2ac68235101c61b736f216cde"
+checksum = "1c233646788d3ae40492affb98185d167bdcc86c8b88ca661d784157404f4f62"
 dependencies = [
  "phf 0.14.0",
  "proc-macro2",
@@ -2896,14 +2896,14 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_visit"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b9d77b5c27575ef7d624de1f226caeca3c0d3fcc2347bdaa788d5c4a85512d"
+checksum = "34ec60272a8dead7c6fb21dd9709f66e4033194399296603a2c9f85dc63b5540"
 dependencies = [
- "oxc_allocator 0.146.0",
- "oxc_ast 0.146.0",
- "oxc_span 0.146.0",
- "oxc_syntax 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast 0.148.0",
+ "oxc_span 0.148.0",
+ "oxc_syntax 0.148.0",
 ]
 
 [[package]]
@@ -2929,23 +2929,24 @@ dependencies = [
 
 [[package]]
 name = "oxc_codegen"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b5180ce6f991eacd8c4a85eb28f9fbbff145422dd8ece782f48626957661d0"
+checksum = "7fff57cbadb9802b778b9941e6e5268df8f54305f75c55399c8e835ee8b366f3"
 dependencies = [
  "bitflags 2.13.1",
  "cow-utils",
- "oxc_allocator 0.146.0",
- "oxc_ast 0.146.0",
- "oxc_data_structures 0.146.0",
- "oxc_ecmascript 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast 0.148.0",
+ "oxc_data_structures 0.148.0",
+ "oxc_ecmascript 0.148.0",
  "oxc_index 5.0.0",
- "oxc_semantic 0.146.0",
+ "oxc_semantic 0.148.0",
  "oxc_sourcemap 8.1.2",
- "oxc_span 0.146.0",
+ "oxc_span 0.148.0",
  "oxc_str",
- "oxc_syntax 0.146.0",
+ "oxc_syntax 0.148.0",
  "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -2963,13 +2964,13 @@ dependencies = [
 
 [[package]]
 name = "oxc_compat"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdfa97a1bb7a8f144937dfb4118ea6e2d681f619c886034f72675b788e1a251"
+checksum = "caef0301ad6c51d21b805600c0b2e30175c4637e41444dff8e8ea9d21d8c4c1c"
 dependencies = [
  "cow-utils",
  "oxc-browserslist 5.0.1",
- "oxc_syntax 0.146.0",
+ "oxc_syntax 0.148.0",
  "rustc-hash",
  "serde",
 ]
@@ -2982,9 +2983,9 @@ checksum = "dd090988aa69c1e394f424289abb9bb1281448a072419ca556a07228ad36b854"
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15a23b57a931fda6bc9a4fdc3fbabcac6a2edfd0b7216cb7c81432f0e9f54d9"
+checksum = "bbe5adfd511d39d3619ce02317368553c79aa290abf1acaf0b4525cec9594e94"
 
 [[package]]
 name = "oxc_diagnostics"
@@ -2999,16 +3000,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d0ce1ec51b07b6501eecedd5ab50835b7ebe5c8463cada3b2e6d984d0943af"
+checksum = "606cda8ae718447dc41af63ec4fc53e99b104bde2fd7a3b9e3b9a4976020aa86"
 dependencies = [
  "bytecount",
  "cow-utils",
  "itoa",
  "memchr",
- "owo-colors",
- "oxc_span 0.146.0",
+ "oxc_span 0.148.0",
  "percent-encoding",
  "smallvec",
  "textwrap",
@@ -3033,22 +3033,22 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5d3d07165b7aadcd021f62cd95fb7d62cb6977b8bbfb42fa12adbfb7e75257"
+checksum = "7c6e7b1ffc464822d838a33858ae95cc672481089c545a883771b8df9ac1d223"
 dependencies = [
  "cow-utils",
  "dragonbox_ecma 0.1.12",
  "itoa",
  "num-bigint 0.5.1",
  "num-traits",
- "oxc_allocator 0.146.0",
- "oxc_ast 0.146.0",
- "oxc_compat 0.146.0",
- "oxc_data_structures 0.146.0",
- "oxc_regular_expression 0.146.0",
- "oxc_span 0.146.0",
- "oxc_syntax 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast 0.148.0",
+ "oxc_compat 0.148.0",
+ "oxc_data_structures 0.148.0",
+ "oxc_regular_expression 0.148.0",
+ "oxc_span 0.148.0",
+ "oxc_syntax 0.148.0",
  "smallvec",
 ]
 
@@ -3060,9 +3060,9 @@ checksum = "af85b24b7e10bf0ccb252f16d38492f51236c1ba146f62013993667cbf7fa649"
 
 [[package]]
 name = "oxc_estree"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7af86a59b7aeb2845ffea2cc21ae259053865b175e9ac936a7d72f2744abe5"
+checksum = "4ac33adcec9582af677f3007e282530f7c8c507df7a3cb335383b79c0c57f574"
 
 [[package]]
 name = "oxc_index"
@@ -3103,20 +3103,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_mangler"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb8c9637d4e67ffa9a97c79fb72b10d0350068e92626eb8bacee8a7d7c1ba02"
+checksum = "435c9d8fd34e9764d25a61c39c57a060f1132dba7410be22646e4a58c9ccfe28"
 dependencies = [
  "itertools 0.15.0",
- "oxc_allocator 0.146.0",
- "oxc_ast 0.146.0",
- "oxc_data_structures 0.146.0",
- "oxc_ecmascript 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast 0.148.0",
+ "oxc_data_structures 0.148.0",
+ "oxc_ecmascript 0.148.0",
  "oxc_index 5.0.0",
- "oxc_semantic 0.146.0",
- "oxc_span 0.146.0",
+ "oxc_semantic 0.148.0",
+ "oxc_span 0.148.0",
  "oxc_str",
- "oxc_syntax 0.146.0",
+ "oxc_syntax 0.148.0",
  "rustc-hash",
 ]
 
@@ -3147,27 +3147,27 @@ dependencies = [
 
 [[package]]
 name = "oxc_minifier"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c7f77fa5af1a2fcd4a8cdd124896341a5889d2f00df3472d12f1dd1e18d0e4"
+checksum = "43a778f7d247c7d5e1c6b6a393424fc1f03e9a93ba44d3ed98ba5660927e376f"
 dependencies = [
  "cow-utils",
  "itoa",
  "lazy-regex",
- "oxc_allocator 0.146.0",
- "oxc_ast 0.146.0",
- "oxc_ast_visit 0.146.0",
- "oxc_compat 0.146.0",
- "oxc_data_structures 0.146.0",
- "oxc_ecmascript 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast 0.148.0",
+ "oxc_ast_visit 0.148.0",
+ "oxc_compat 0.148.0",
+ "oxc_data_structures 0.148.0",
+ "oxc_ecmascript 0.148.0",
  "oxc_index 5.0.0",
- "oxc_mangler 0.146.0",
- "oxc_parser 0.146.0",
- "oxc_semantic 0.146.0",
- "oxc_span 0.146.0",
+ "oxc_mangler 0.148.0",
+ "oxc_parser 0.148.0",
+ "oxc_semantic 0.148.0",
+ "oxc_span 0.148.0",
  "oxc_str",
- "oxc_syntax 0.146.0",
- "oxc_traverse 0.146.0",
+ "oxc_syntax 0.148.0",
+ "oxc_traverse 0.148.0",
  "rustc-hash",
 ]
 
@@ -3196,24 +3196,24 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311c29dfdf55ea8bf065cf300b3d0dca5fe1c0fb8059c9ba70a6c98cce75306e"
+checksum = "9e7efce258a7587eac02e028db4121ac5c6935e4e2d46ea9cba7f54aa1919459"
 dependencies = [
  "bitflags 2.13.1",
  "cow-utils",
  "memchr",
  "num-bigint 0.5.1",
  "num-traits",
- "oxc_allocator 0.146.0",
- "oxc_ast 0.146.0",
- "oxc_data_structures 0.146.0",
- "oxc_diagnostics 0.146.0",
- "oxc_ecmascript 0.146.0",
- "oxc_regular_expression 0.146.0",
- "oxc_span 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast 0.148.0",
+ "oxc_data_structures 0.148.0",
+ "oxc_diagnostics 0.148.0",
+ "oxc_ecmascript 0.148.0",
+ "oxc_regular_expression 0.148.0",
+ "oxc_span 0.148.0",
  "oxc_str",
- "oxc_syntax 0.146.0",
+ "oxc_syntax 0.148.0",
  "rustc-hash",
  "seq-macro",
 ]
@@ -3236,15 +3236,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31839a373ad02a37fad54244a3eb710f9a94b5e2e16ca0e1d28a37b4c75b8ebc"
+checksum = "3d4d2d6468b4c6c02595c735e337386d77b093ba91f71dd64242c12560b0f586"
 dependencies = [
  "bitflags 2.13.1",
- "oxc_allocator 0.146.0",
- "oxc_ast_macros 0.146.0",
- "oxc_diagnostics 0.146.0",
- "oxc_span 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast_macros 0.148.0",
+ "oxc_diagnostics 0.148.0",
+ "oxc_span 0.148.0",
  "oxc_str",
  "phf 0.14.0",
  "rustc-hash",
@@ -3274,22 +3274,22 @@ dependencies = [
 
 [[package]]
 name = "oxc_semantic"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366191309f606847936aade62707b06683ed5e0b0c8cb66c27710a61f64a50f1"
+checksum = "183e66113ce154ec259a4843eee1ba465306d12ff08374f5a72eae6e773c3a49"
 dependencies = [
  "itertools 0.15.0",
  "memchr",
- "oxc_allocator 0.146.0",
- "oxc_ast 0.146.0",
- "oxc_ast_visit 0.146.0",
- "oxc_data_structures 0.146.0",
- "oxc_diagnostics 0.146.0",
- "oxc_ecmascript 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast 0.148.0",
+ "oxc_ast_visit 0.148.0",
+ "oxc_data_structures 0.148.0",
+ "oxc_diagnostics 0.148.0",
+ "oxc_ecmascript 0.148.0",
  "oxc_index 5.0.0",
- "oxc_span 0.146.0",
+ "oxc_span 0.148.0",
  "oxc_str",
- "oxc_syntax 0.146.0",
+ "oxc_syntax 0.148.0",
  "rustc-hash",
  "self_cell",
  "smallvec",
@@ -3336,27 +3336,27 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c355ae1fa3e865c28cb8a85735ecafd1bb6340a5b880c638d127c1f2d61a98a5"
+checksum = "d0d038b28e7037ab6dfded105eb35d12cdc58f6b9959dee9ae3244142fd45852"
 dependencies = [
  "compact_str 0.10.0",
- "oxc_allocator 0.146.0",
- "oxc_ast_macros 0.146.0",
- "oxc_estree 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast_macros 0.148.0",
+ "oxc_estree 0.148.0",
  "oxc_str",
 ]
 
 [[package]]
 name = "oxc_str"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba45ef9efa8296e647aa37b2b21936cb520953031edc1ef6352281bbea22faa"
+checksum = "463caa681dcd52935465805af52f4fc8661c723b6ba36c6822222efb6078e655"
 dependencies = [
  "compact_str 0.10.0",
  "hashbrown 0.17.1",
- "oxc_allocator 0.146.0",
- "oxc_estree 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_estree 0.148.0",
 ]
 
 [[package]]
@@ -3381,19 +3381,19 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0970d9be099a082711b574d58add258549580a70fe6546b99a067bbd7ad4a264"
+checksum = "460be58ae9013ebe0604cdfc0f558e71109e2ee948da5f9b40bc493056631e2d"
 dependencies = [
  "bitflags 2.13.1",
  "cow-utils",
  "dragonbox_ecma 0.1.12",
  "nonmax",
- "oxc_allocator 0.146.0",
- "oxc_ast_macros 0.146.0",
- "oxc_estree 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast_macros 0.148.0",
+ "oxc_estree 0.148.0",
  "oxc_index 5.0.0",
- "oxc_span 0.146.0",
+ "oxc_span 0.148.0",
  "oxc_str",
  "phf 0.14.0",
  "unicode-id-start",
@@ -3419,20 +3419,20 @@ dependencies = [
 
 [[package]]
 name = "oxc_traverse"
-version = "0.146.0"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f214c06bfb15427400f7c11fe4487ebeb4d5740b0803ff5f1a1c895198e40a30"
+checksum = "e3fed7411606d1abcd794eed551320c387a744a5ca5c3a489a5a5e8a95d1e724"
 dependencies = [
  "itoa",
- "oxc_allocator 0.146.0",
- "oxc_ast 0.146.0",
- "oxc_ast_visit 0.146.0",
- "oxc_data_structures 0.146.0",
- "oxc_ecmascript 0.146.0",
- "oxc_semantic 0.146.0",
- "oxc_span 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_ast 0.148.0",
+ "oxc_ast_visit 0.148.0",
+ "oxc_data_structures 0.148.0",
+ "oxc_ecmascript 0.148.0",
+ "oxc_semantic 0.148.0",
+ "oxc_span 0.148.0",
  "oxc_str",
- "oxc_syntax 0.146.0",
+ "oxc_syntax 0.148.0",
  "rustc-hash",
 ]
 
@@ -4775,11 +4775,11 @@ dependencies = [
  "minijinja",
  "notify",
  "noyalib",
- "oxc_allocator 0.146.0",
- "oxc_codegen 0.146.0",
- "oxc_minifier 0.146.0",
- "oxc_parser 0.146.0",
- "oxc_span 0.146.0",
+ "oxc_allocator 0.148.0",
+ "oxc_codegen 0.148.0",
+ "oxc_minifier 0.148.0",
+ "oxc_parser 0.148.0",
+ "oxc_span 0.148.0",
  "proptest",
  "pulldown-cmark",
  "ravif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,11 +250,11 @@ rgb = { version = "0.8", optional = true }
 # Versions pinned to those already resolved transitively via
 # staticdatagen to keep the dependency graph tight.
 minify-html = { version = "0.18.1", optional = true }
-oxc_minifier = { version = "0.146.0", optional = true }
-oxc_parser = { version = "0.146.0", optional = true }
-oxc_codegen = { version = "0.146.0", optional = true }
-oxc_allocator = { version = "0.146.0", optional = true }
-oxc_span = { version = "0.146.0", optional = true }
+oxc_minifier = { version = "0.148.0", optional = true }
+oxc_parser = { version = "0.148.0", optional = true }
+oxc_codegen = { version = "0.148.0", optional = true }
+oxc_allocator = { version = "0.148.0", optional = true }
+oxc_span = { version = "0.148.0", optional = true }
 lightningcss = { version = "1.0.0-alpha.71", optional = true }
 walkdir = { version = "2.5", optional = true }
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -956,7 +956,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_allocator]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast]]
@@ -964,7 +964,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast_macros]]
@@ -972,7 +972,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast_macros]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast_visit]]
@@ -980,7 +980,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ast_visit]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_codegen]]
@@ -988,7 +988,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_codegen]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_compat]]
@@ -996,7 +996,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_compat]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_data_structures]]
@@ -1004,7 +1004,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_data_structures]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_diagnostics]]
@@ -1012,7 +1012,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_diagnostics]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ecmascript]]
@@ -1020,7 +1020,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_ecmascript]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_estree]]
@@ -1028,7 +1028,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_estree]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_index]]
@@ -1044,7 +1044,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_mangler]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_minifier]]
@@ -1052,7 +1052,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_minifier]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_parser]]
@@ -1060,7 +1060,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_parser]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_regular_expression]]
@@ -1068,7 +1068,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_regular_expression]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_semantic]]
@@ -1076,7 +1076,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_semantic]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_sourcemap]]
@@ -1092,11 +1092,11 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_span]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_str]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_syntax]]
@@ -1104,7 +1104,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_syntax]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_traverse]]
@@ -1112,7 +1112,7 @@ version = "0.95.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.oxc_traverse]]
-version = "0.146.0"
+version = "0.148.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.page_size]]


### PR DESCRIPTION
Replaces #757, #758, #759, #760 and #761.

Dependabot opened those five one per oxc crate, and **none of them can
pass on its own**. The oxc crates share an AST, so bumping `oxc_codegen`
while `oxc_parser` stays at 0.146.0 produces:

```
error[E0308]: mismatched types
   --> src/plugins/plugins.rs:332:66
    |
332 |     let out = Codegen::new().with_options(codegen_options).build(&program);
    |               expected `oxc_ast::ast::js::Program<'_>`, found a different `Program`
```

The strict clippy job fails on that, which is why all five sat blocked
rather than merging.

All five move together here: `oxc_allocator`, `oxc_codegen`,
`oxc_minifier`, `oxc_parser`, `oxc_span`, 0.146.0 → 0.148.0.

## Verification

| Gate | Result |
|---|---|
| CI-identical clippy | clean |
| `cargo test --all-features` | 66 suites, **4,966 tests**, 0 failures |
| `cargo vet --locked` | succeeds; 504 exempted, baseline 555 |

The golden-file suite passes unchanged, so the minifier upgrade alters
no generated byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3PuhcVtzgYv55e7xE8A3X