### PR TITLE
docs(readme): add the OpenSSF Best Practices badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   <a href="#license"><img src="https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg?style=for-the-badge" alt="License: MIT OR Apache-2.0" /></a>
   <a href="#minimum-supported-rust-version"><img src="https://img.shields.io/badge/MSRV-1.88.0-dea584.svg?style=for-the-badge&logo=rust" alt="MSRV 1.88.0" /></a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/sebastienrousseau/static-site-generator"><img src="https://img.shields.io/ossf-scorecard/github.com/sebastienrousseau/static-site-generator?style=for-the-badge&label=openssf%20scorecard" alt="OpenSSF Scorecard" /></a>
+  <a href="https://www.bestpractices.dev/projects/14540"><img src="https://img.shields.io/cii/level/14540?style=for-the-badge&label=OpenSSF%20Best%20Practices&logo=openssf" alt="OpenSSF Best Practices" /></a>
 </p>
 
 ---


### PR DESCRIPTION
Registers the repository on bestpractices.dev and shows the badge it earned.

The project now holds an OpenSSF **passing** badge at 100% of the passing criteria. Every one of the 67 criteria was answered against something that exists on `main` and was checked before it was claimed; the ten that do not apply (this crate performs no cryptographic operations, and no publicly known vulnerability has been fixed in a release) are marked N/A with a reason rather than asserted.

This raises the `CII-Best-Practices` check in the OpenSSF Scorecard from 0 to its maximum for the passing level.

Badge markup matches noyalib's so the family headers stay uniform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3PuhcVtzgYv55e7xE8A3X