### PR TITLE
fix(packaging): the rpm asset pinned one architecture and blocked the release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,11 +559,19 @@ strip = false                               # Do not strip symbols in test build
 # Packaging metadata
 # -----------------------------------------------------------------------------
 
-# cargo-generate-rpm — used by .github/workflows/release.yml to produce
-# `ssg-X.Y.Z-1.x86_64.rpm` for Fedora / RHEL / openSUSE consumers.
+# cargo-generate-rpm — used by the release workflow to produce
+# `ssg-X.Y.Z-1.<arch>.rpm` for Fedora / RHEL / openSUSE consumers.
+#
+# The binary's source path must stay `target/release/...`. cargo-generate-rpm
+# rewrites that prefix to `target/<triple>/release/` when `--target` is given,
+# which is how one entry serves both x86_64 and aarch64. Naming a triple here
+# instead pins the asset to that one architecture: the aarch64 leg of the
+# v0.0.60 release failed with `Asset file not found:
+# target/x86_64-unknown-linux-gnu/release/ssg`, and because every later job
+# needs all builds green, the crates.io publish was skipped with it.
 [package.metadata.generate-rpm]
 assets = [
-    { source = "target/x86_64-unknown-linux-gnu/release/ssg", dest = "/usr/bin/ssg", mode = "755" },
+    { source = "target/release/ssg", dest = "/usr/bin/ssg", mode = "755" },
     { source = "LICENSE-MIT",    dest = "/usr/share/doc/ssg/LICENSE-MIT",    mode = "644", doc = true },
     { source = "LICENSE-APACHE", dest = "/usr/share/doc/ssg/LICENSE-APACHE", mode = "644", doc = true },
     { source = "README.md",      dest = "/usr/share/doc/ssg/README.md",      mode = "644", doc = true },


### PR DESCRIPTION
The **v0.0.60 release run failed**. `build · aarch64-unknown-linux-gnu` died at "Build .rpm" with:

```
Asset file not found: target/x86_64-unknown-linux-gnu/release/ssg
```

Because the publish jobs need every build green, `github release · crates.io` was skipped along with provenance, signing and the container push. **Nothing shipped** — crates.io is still on 0.0.56.

## Cause

`[package.metadata.generate-rpm]` named the x86_64 triple directly in the binary's asset source. cargo-generate-rpm rewrites a `target/release/` prefix to `target/<triple>/release/` when `--target` is passed, so a single entry serves both architectures — but only while the prefix stays generic. Spelling a triple out defeats the rewrite and pins the asset to that one architecture.

## Verification

Reproduced locally against cargo-generate-rpm 0.21.0:

```
# before
$ cargo generate-rpm --target aarch64-unknown-linux-gnu
Asset file not found: target/x86_64-unknown-linux-gnu/release/ssg   ← the CI error, exactly

# after
$ cargo generate-rpm --target aarch64-unknown-linux-gnu
Asset file not found: target/aarch64-unknown-linux-gnu/release/ssg
$ cargo generate-rpm --target x86_64-unknown-linux-gnu
Asset file not found: target/x86_64-unknown-linux-gnu/release/ssg   ← unchanged, no regression
```

Each now resolves to its own architecture. End to end, with a binary actually present:

```
$ cargo build --release --bin ssg && cargo generate-rpm
target/generate-rpm/ssg-0.0.60-1.aarch64.rpm   4116703 bytes, carries /usr/bin/ssg
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3PuhcVtzgYv55e7xE8A3X