### PR TITLE
fix(release): a broken third-party apt index must not fail the release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,8 +520,17 @@ jobs:
       # without them the script skips those steps and would report a pass
       # it did not earn.
       - name: Install shells and the roff linter
+        # The hosted runner image configures third-party apt sources this
+        # job never installs from — Google Chrome among them. When one
+        # serves a bad index, `apt-get update` exits 100 and fails the job.
+        # Dropping them first keeps their availability off the critical
+        # path; see the same guard in release.yml.
         run: |
-          sudo apt-get update -qq
+          set -euo pipefail
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update -qq \
+            || echo "apt-get update reported an error; continuing"
           sudo apt-get install -y --no-install-recommends zsh fish mandoc
       - name: make DESTDIR=/tmp/stage install
         run: ./scripts/install-smoke.sh /tmp/stage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,31 @@ jobs:
           targets: ${{ matrix.target }}
 
       - if: matrix.musl
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
+        name: Install musl-tools
+        # The hosted x86_64 runner image configures third-party apt sources
+        # this job has no use for — Google Chrome among them. When one serves
+        # a bad index, `apt-get update` exits 100 and takes the release with
+        # it, even though every Ubuntu index fetched cleanly. That is what
+        # blocked v0.0.60 three runs in a row:
+        #
+        #   E: Failed to fetch https://dl.google.com/linux/chrome-stable/...
+        #      Packages.gz  Hash Sum mismatch
+        #
+        # The aarch64 image carries no such source, so the same step passed
+        # there and failed here for a reason belonging to neither.
+        #
+        # Drop the sources we never install from, then let a residual update
+        # failure through. This weakens nothing: `apt-get install` below is
+        # the real gate and still fails loudly if musl-tools is genuinely
+        # unavailable. An unreachable mirror for a repo we do not use is not
+        # a reason to fail a release.
+        run: |
+          set -euo pipefail
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update \
+            || echo "apt-get update reported an error; continuing"
+          sudo apt-get install -y musl-tools
 
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
         with:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -159,7 +159,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: x86_64-unknown-linux-musl
-      - run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Install musl-tools
+        # The hosted runner image configures third-party apt sources this
+        # job never installs from — Google Chrome among them. When one
+        # serves a bad index, `apt-get update` exits 100 and fails the job.
+        # Dropping them first keeps their availability off the critical
+        # path; see the same guard in release.yml.
+        run: |
+          set -euo pipefail
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update \
+            || echo "apt-get update reported an error; continuing"
+          sudo apt-get install -y musl-tools
       - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
         with:
           shared-key: musl

--- a/.github/workflows/visual.yml
+++ b/.github/workflows/visual.yml
@@ -41,7 +41,15 @@ jobs:
 
       - name: Install Playwright
         working-directory: tests/visual
+        # The hosted runner image configures third-party apt sources this
+        # job never installs from — Google Chrome among them. When one
+        # serves a bad index, `apt-get update` exits 100 and fails the job.
+        # Dropping them first keeps their availability off the critical
+        # path; see the same guard in release.yml.
         run: |
+          set -euo pipefail
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
           npm ci
           npx playwright install --with-deps chromium webkit
 
@@ -100,7 +108,15 @@ jobs:
 
       - name: Install Playwright
         working-directory: tests/visual
+        # The hosted runner image configures third-party apt sources this
+        # job never installs from — Google Chrome among them. When one
+        # serves a bad index, `apt-get update` exits 100 and fails the job.
+        # Dropping them first keeps their availability off the critical
+        # path; see the same guard in release.yml.
         run: |
+          set -euo pipefail
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/microsoft-prod.list
           npm ci
           npx playwright install --with-deps chromium webkit
 


### PR DESCRIPTION
v0.0.60 has failed to publish **three times**. The `x86_64-unknown-linux-musl` build dies before compiling anything:

```
E: Failed to fetch https://dl.google.com/linux/chrome-stable/deb/dists/stable/main/binary-amd64/Packages.gz  Hash Sum mismatch
E: Some index files failed to download.
```

Every Ubuntu index fetched cleanly. The only failure is **Google's Chrome repository** — configured by the hosted x86_64 runner image, and installed from by nothing here. `apt-get update` still exits 100, and because every later job needs all builds green, `github release · crates.io` was skipped with it.

The aarch64 image carries no such source, so the same step passed there and failed here for a reason belonging to neither. Reproduced across three runs spanning more than two hours.

## Changes

- Remove the third-party apt sources this job has no use for before updating, so their availability stops being load-bearing.
- Let a residual `apt-get update` failure through. This weakens nothing: `apt-get install` still runs under `set -e` and fails loudly if `musl-tools` is genuinely unavailable — that is the condition worth failing a release on. An unreachable mirror for a repository we never install from is not.

## Verification

- workflow YAML parses
- the new `run` body passes `bash -n`

Once merged, `v0.0.60` needs re-tagging onto the fixed commit so the release run picks this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3PuhcVtzgYv55e7xE8A3X