### PR TITLE
fix(release): a leftover draft can capture the whole release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -633,7 +633,21 @@ jobs:
           # makes the job safe to re-run after a partial failure
           # (e.g. crates.io token rotation between attempts) without
           # the "release already exists" abort.
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+          #
+          # The existence check goes through the REST endpoint for a tag,
+          # not `gh release view`. `gh` resolves a name as well as a tag,
+          # so it matches DRAFT releases too — and a draft has no tag at
+          # all until it is published. In v0.0.60 a leftover draft named
+          # `v0.0.60` shadowed the real tagged release: this job took the
+          # "already exists" branch, uploaded all 43 signed artifacts into
+          # the draft, and the release users could actually see was left
+          # holding nothing but the SLSA provenance file. It was green
+          # throughout.
+          #
+          # `/releases/tags/<tag>` only ever resolves a published release
+          # with that tag, so a stray draft cannot capture the upload.
+          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" \
+               >/dev/null 2>&1; then
             echo "Release $GITHUB_REF_NAME already exists — updating in place"
             gh release edit "$GITHUB_REF_NAME" \
               --title "$GITHUB_REF_NAME" \
@@ -645,6 +659,20 @@ jobs:
               --notes-file /tmp/release-body.md \
               --generate-notes \
               artifacts/*
+          fi
+
+          # Whichever branch ran, the tagged release must now carry every
+          # artifact. Checking this here is the difference between the
+          # v0.0.60 failure being caught by CI and being caught by a user
+          # who could not download a binary.
+          expected=$(find artifacts -maxdepth 1 -type f | wc -l | tr -d ' ')
+          actual=$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$GITHUB_REF_NAME" \
+                     --jq '.assets | length')
+          echo "release assets: $actual (expected at least $expected)"
+          if [ "$actual" -lt "$expected" ]; then
+            echo "::error::the tagged release carries $actual asset(s)" \
+                 "but $expected were built — something else captured the upload"
+            exit 1
           fi
 
       - name: Attest build provenance


### PR DESCRIPTION
v0.0.60 published to crates.io, went green end to end, and left users a release page with **one file** on it: the SLSA provenance. All 43 signed binaries, rpms, pkgs and checksums went into a draft nobody could see.

## Cause

`gh release view "$GITHUB_REF_NAME"` resolves a release **name** as well as a tag, so it matches drafts — and a draft has no tag until it is published. A leftover draft named `v0.0.60` satisfied the existence check, the job took its `already exists — updating in place` branch, and `gh release upload` put every artifact into that draft. The tagged release users actually see was created separately, later, by the SLSA job, and got only what that job uploaded.

**Nothing failed. The run was green.** That is what makes it worth a gate.

## Changes

**1. Check existence via the tags endpoint.** `repos/:owner/:repo/releases/tags/<tag>` only ever resolves a published release carrying that tag. Verified against this repository while both objects still existed:

```
$ gh api repos/.../releases/tags/v0.0.60 --jq .id,.draft
385921862   false     ← the published release
# the draft is 385768278, which `gh release view` had been matching
```

**2. Assert the asset count.** After either branch, the tagged release must carry at least as many assets as were built. This is the check that would have caught the problem at release time instead of leaving it for someone trying to download a binary.

## Verification

- workflow parses as YAML
- the full `run` block passes `bash -n`

The v0.0.60 release page has since been repaired by hand: all 43 artifacts were copied onto the published release and each verified against its `.sha256`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3PuhcVtzgYv55e7xE8A3X