### PR TITLE
fix(examples): examples/basic could not be built, and said so unhelpfully

### DIFF
--- a/examples/basic/templates/index.html
+++ b/examples/basic/templates/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="{{language}}">
+<head>
+  <meta charset="{{charset}}" />
+  <meta name="viewport" content="{{viewport}}" />
+  <title>{{title}}</title>
+  <meta name="description" content="{{description}}" />
+  <link rel="canonical" href="{{permalink}}" />
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <a href="#main-content" class="sr-only">Skip to main content</a>
+  <header role="banner">
+    <nav aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/about/">About</a>
+    </nav>
+  </header>
+  <main id="main-content" role="main">
+    {{!content}}
+  </main>
+  <footer role="contentinfo">
+    <p>Built with <a href="https://static-site-generator.one">SSG</a>.</p>
+  </footer>
+</body>
+</html>

--- a/examples/basic/templates/page.html
+++ b/examples/basic/templates/page.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="{{language}}">
+<head>
+  <meta charset="{{charset}}" />
+  <meta name="viewport" content="{{viewport}}" />
+  <title>{{title}}</title>
+  <meta name="description" content="{{description}}" />
+  <link rel="canonical" href="{{permalink}}" />
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <a href="#main-content" class="sr-only">Skip to main content</a>
+  <header role="banner">
+    <nav aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/about/">About</a>
+    </nav>
+  </header>
+  <main id="main-content" role="main">
+    {{!content}}
+  </main>
+  <footer role="contentinfo">
+    <p>Built with <a href="https://static-site-generator.one">SSG</a>.</p>
+  </footer>
+</body>
+</html>

--- a/examples/basic/templates/post.html
+++ b/examples/basic/templates/post.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="{{language}}">
+<head>
+  <meta charset="{{charset}}" />
+  <meta name="viewport" content="{{viewport}}" />
+  <title>{{title}}</title>
+  <meta name="description" content="{{description}}" />
+  <link rel="canonical" href="{{permalink}}" />
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <a href="#main-content" class="sr-only">Skip to main content</a>
+  <header role="banner">
+    <nav aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/about/">About</a>
+    </nav>
+  </header>
+  <main id="main-content" role="main">
+    {{!content}}
+  </main>
+  <footer role="contentinfo">
+    <p>Built with <a href="https://static-site-generator.one">SSG</a>.</p>
+  </footer>
+</body>
+</html>

--- a/examples/basic/templates/template.html
+++ b/examples/basic/templates/template.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="{{language}}">
+<head>
+  <meta charset="{{charset}}" />
+  <meta name="viewport" content="{{viewport}}" />
+  <title>{{title}}</title>
+  <meta name="description" content="{{description}}" />
+  <link rel="canonical" href="{{permalink}}" />
+  <link rel="stylesheet" href="/css/style.css" />
+</head>
+<body>
+  <a href="#main-content" class="sr-only">Skip to main content</a>
+  <header role="banner">
+    <nav aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/about/">About</a>
+    </nav>
+  </header>
+  <main id="main-content" role="main">
+    {{!content}}
+  </main>
+  <footer role="contentinfo">
+    <p>Built with <a href="https://static-site-generator.one">SSG</a>.</p>
+  </footer>
+</body>
+</html>

--- a/examples/basic/templates/tera/base.html
+++ b/examples/basic/templates/tera/base.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="{{ site.language | default(value='en') }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}{{ page.title | default(value="Untitled") }}{% if site.title %} — {{ site.title }}{% endif %}{% endblock %}</title>
+  {# `page` is absent on taxonomy pages, which render through this
+     same base with `tag`/`posts` in scope instead. Without the
+     `is defined` guard the whole build aborts with
+     `undefined value (in base.html:7)` while naming `tag.html`,
+     a file the author never wrote. #}
+  {% if page is defined and page.description %}<meta name="description" content="{{ page.description }}">{% endif %}
+  <link rel="stylesheet" href="/css/style.css">
+  {% block head_extra %}{% endblock %}
+</head>
+<body>
+  <a href="#main-content" class="sr-only">Skip to main content</a>
+  <header role="banner">
+    <nav aria-label="Main navigation">
+      <a href="/">{{ site.name | default(value="Home") }}</a>
+      <a href="/about.html">About</a>
+    </nav>
+  </header>
+  <main id="main-content" role="main">
+    {% block content %}{% endblock %}
+  </main>
+  <footer role="contentinfo">
+    <p>&copy; {{ site.name | default(value="") }}. Built with <a href="https://static-site-generator.one">SSG</a>.</p>
+  </footer>
+</body>
+</html>

--- a/examples/basic/templates/tera/index.html
+++ b/examples/basic/templates/tera/index.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}{{ site.title | default(value="Home") }}{% endblock %}
+{% block content %}
+<section>{{ page.content | safe }}</section>
+{% endblock %}

--- a/examples/basic/templates/tera/page.html
+++ b/examples/basic/templates/tera/page.html
@@ -1,0 +1,2 @@
+{% extends "base.html" %}
+{% block content %}{{ page.content | safe }}{% endblock %}

--- a/examples/basic/templates/tera/post.html
+++ b/examples/basic/templates/tera/post.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+<article>
+  <header>
+    <h1>{{ page.title | default(value="") }}</h1>
+    {% if page.date %}<time datetime="{{ page.date }}">{{ page.date }}</time>{% endif %}
+    {% if page.author %}<span class="author">by {{ page.author }}</span>{% endif %}
+    {% if page.content %}<span class="reading-time">{{ page.content | reading_time }}</span>{% endif %}
+  </header>
+  <div class="post-body">{{ page.content | safe }}</div>
+  {% if page.tags %}
+  <footer>
+    <ul class="tags" aria-label="Tags">
+      {% for tag in page.tags %}<li><a href="/tags/{{ tag | slugify }}/">{{ tag }}</a></li>{% endfor %}
+    </ul>
+  </footer>
+  {% endif %}
+</article>
+{% endblock %}

--- a/src/core/pipeline.rs
+++ b/src/core/pipeline.rs
@@ -800,9 +800,52 @@ pub fn compile_site_with_locales(
         )
         .map_err(|e| SsgError::io(e, content_dir))?;
 
+    // `compile` reads the StaticWeaver templates from the root of the
+    // template directory, choosing one per page from its layout. Which
+    // of them a given site needs therefore depends on its content —
+    // a project with only `page.html` builds fine — so this is not a
+    // precondition that can be checked up front.
+    //
+    // What it is is undiagnosable when it fails. StaticWeaver surfaces a
+    // bare `No such file or directory` carrying no path, and the wrapper
+    // could only name `build_dir`: the directory being written *to*. A
+    // user following `examples/basic`, which shipped without templates,
+    // was told `I/O error at 'public.build-tmp'` about a file under
+    // `templates/` that had never existed (issue #752, and again on a
+    // hand-made project in v0.0.60).
+    //
+    // So keep the behaviour and fix the diagnosis: on a not-found,
+    // report the template directory and which of the usual four are
+    // absent from it.
     compile(build_dir, &staged_content, site_dir, template_dir).map_err(
         |e| {
             eprintln!("    Error compiling site: {e:?}");
+            if format!("{e:?}").contains("No such file or directory") {
+                const USUAL_ROOT_TEMPLATES: [&str; 4] =
+                    ["template.html", "index.html", "page.html", "post.html"];
+                let absent: Vec<&str> = USUAL_ROOT_TEMPLATES
+                    .iter()
+                    .copied()
+                    .filter(|name| !template_dir.join(name).is_file())
+                    .collect();
+                if !absent.is_empty() {
+                    return SsgError::Validation {
+                        field: "templates".to_string(),
+                        message: format!(
+                            "the compile step could not read a template. \
+                             {} does not contain {}. A site needs the \
+                             templates its content asks for at the template \
+                             directory root, plus the MiniJinja set under \
+                             `{}`. Run `ssg --new <name>` to scaffold a \
+                             project with both, or copy them from \
+                             `examples/basic/templates/`.",
+                            template_dir.display(),
+                            absent.join(", "),
+                            template_dir.join("tera").display(),
+                        ),
+                    };
+                }
+            }
             SsgError::io(
                 std::io::Error::other(format!("Failed to compile site: {e:?}")),
                 build_dir,

--- a/src/core/pipeline.rs
+++ b/src/core/pipeline.rs
@@ -820,7 +820,31 @@ pub fn compile_site_with_locales(
     compile(build_dir, &staged_content, site_dir, template_dir).map_err(
         |e| {
             eprintln!("    Error compiling site: {e:?}");
-            if format!("{e:?}").contains("No such file or directory") {
+            // Portability: the not-found test must not be a match on
+            // English Unix wording. Windows says "The system cannot
+            // find the file specified.", so `contains("No such file or
+            // directory")` silently never fired there and the
+            // diagnostic below was dead on that platform — caught by
+            // the windows-latest leg of CI, not by review.
+            //
+            // Prefer the error kind, which is platform-independent.
+            // Fall back to the platform's *own* text for ENOENT, taken
+            // from the OS at runtime rather than hardcoded, for the
+            // case where the chain has flattened the io::Error into a
+            // formatted string.
+            let enoent = std::io::Error::from_raw_os_error(2).to_string();
+            // "No such file or directory (os error 2)" on Unix; "The
+            // system cannot find the file specified. (os error 2)" on
+            // Windows. Compare on the prose alone — the numeric suffix
+            // is not guaranteed to survive re-formatting.
+            let enoent_prose =
+                enoent.split(" (os error").next().unwrap_or(&enoent);
+            let not_found = e.chain().any(|cause| {
+                cause
+                    .downcast_ref::<std::io::Error>()
+                    .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
+            }) || format!("{e:?}").contains(enoent_prose);
+            if not_found {
                 const USUAL_ROOT_TEMPLATES: [&str; 4] =
                     ["template.html", "index.html", "page.html", "post.html"];
                 let absent: Vec<&str> = USUAL_ROOT_TEMPLATES

--- a/tests/core/pipeline.rs
+++ b/tests/core/pipeline.rs
@@ -250,3 +250,49 @@ fn a_missing_root_template_is_named_rather_than_reported_as_io_at_the_output_dir
         "the error should not point at the output directory, got: {msg}"
     );
 }
+
+/// The counterpart to the test above: the diagnostic must not claim
+/// templates are missing when they are all present. A page asking for a
+/// layout that does not exist also fails not-found, and there the
+/// honest answer is the original I/O error — pointing at a template
+/// directory that does contain the four usual files would send the
+/// reader somewhere there is nothing to find.
+#[test]
+fn a_not_found_with_every_root_template_present_keeps_the_io_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let content = root.join("content");
+    let templates = root.join("templates");
+    std::fs::create_dir_all(&content).expect("content dir");
+    std::fs::create_dir_all(templates.join("tera")).expect("tera dir");
+    for name in ["template.html", "index.html", "page.html", "post.html"] {
+        std::fs::write(
+            templates.join(name),
+            "<!DOCTYPE html><html><body>{{content}}</body></html>\n",
+        )
+        .expect("write root template");
+    }
+    std::fs::write(
+        content.join("index.md"),
+        "---\ntitle: T\nlayout: nonexistent-layout\n---\n\nBody\n",
+    )
+    .expect("write content");
+
+    let err = ssg::pipeline::compile_site(
+        &root.join("public.build-tmp"),
+        &content,
+        &root.join("public"),
+        &templates,
+    )
+    .expect_err("a missing layout must still fail");
+
+    let msg = err.to_string();
+    assert!(
+        !msg.contains("does not contain"),
+        "must not blame the templates when all four are present: {msg}"
+    );
+    assert!(
+        msg.contains("Failed to compile site"),
+        "the original compile error should survive: {msg}"
+    );
+}

--- a/tests/core/pipeline.rs
+++ b/tests/core/pipeline.rs
@@ -203,3 +203,50 @@ fn compile_without_base_url_keeps_author_permalinks_verbatim() {
         "author permalink must pass through verbatim: {feed}"
     );
 }
+
+/// A project with content but no templates used to fail with
+/// `I/O error at 'public.build-tmp': ... No such file or directory` —
+/// naming the directory being written *to*, and no path for the file
+/// that was actually absent. `examples/basic` shipped in exactly that
+/// state, so following it verbatim produced an undiagnosable error.
+///
+/// The build must now name the missing templates and say how to get
+/// them.
+#[test]
+fn a_missing_root_template_is_named_rather_than_reported_as_io_at_the_output_dir(
+) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    let content = root.join("content");
+    let templates = root.join("templates");
+    std::fs::create_dir_all(&content).expect("content dir");
+    // The MiniJinja set alone is not enough: the StaticWeaver stage runs
+    // first and reads the template directory root.
+    std::fs::create_dir_all(templates.join("tera")).expect("tera dir");
+    std::fs::write(content.join("index.md"), "---\ntitle: T\n---\n\nBody\n")
+        .expect("write content");
+
+    let err = ssg::pipeline::compile_site(
+        &root.join("public.build-tmp"),
+        &content,
+        &root.join("public"),
+        &templates,
+    )
+    .expect_err("a project with no root templates must not build");
+
+    let msg = err.to_string();
+    for name in ["template.html", "index.html", "page.html", "post.html"] {
+        assert!(
+            msg.contains(name),
+            "the error should name the missing {name}, got: {msg}"
+        );
+    }
+    assert!(
+        msg.contains("ssg --new"),
+        "the error should say how to get the templates, got: {msg}"
+    );
+    assert!(
+        !msg.contains("public.build-tmp"),
+        "the error should not point at the output directory, got: {msg}"
+    );
+}


### PR DESCRIPTION
Found by installing the published v0.0.60 from crates.io and following the example.

## 1. `examples/basic` shipped without templates

It had `content/` and no `templates/`, so following it verbatim produced a failed build. It now carries the eight templates a project needs:

- four StaticWeaver templates at the template-directory **root** (`template.html`, `index.html`, `page.html`, `post.html`) — read by the compile stage
- four MiniJinja templates under **`templates/tera/`** — read by the plugin stage

These are the scaffolder’s own set (minimal, no CDN host baked in) rather than the site-specific templates at the repository root.

`examples/basic` now builds **11 pages**.

## 2. The failure was close to undiagnosable

```
Error compiling site: I/O error: No such file or directory (os error 2)
Program encountered an error: I/O error at 'public.build-tmp':
Failed to compile site: I/O error: No such file or directory
```

`public.build-tmp` is the directory being written *to*. Nothing in that message points at `templates/`. StaticWeaver surfaces a bare not-found carrying no path, and the wrapper had nothing better to name. Now:

```
Validation failed for field 'templates': the compile step could not read a
template. <dir> does not contain template.html, index.html, page.html,
post.html. A site needs the templates its content asks for at the template
directory root, plus the MiniJinja set under `<dir>/tera`. Run `ssg --new
<name>` to scaffold a project with both, or copy them from
`examples/basic/templates/`.
```

## It diagnoses rather than pre-empts — deliberately

My first attempt required all four templates up front and **broke two existing tests**. Which templates a site needs depends on its content: a project with only `page.html` builds fine. So the check runs on the not-found path only, and behaviour for every project that builds today is unchanged.

## Verification

The regression test was **seen to fail without the fix**, with exactly the old message:

```
the error should name the missing template.html, got: I/O error at
'.../public.build-tmp': Failed to compile site: I/O error: No such file
or directory (os error 2)
```

96 core tests and 8 release-version tests pass. `cargo fmt --check`, `cargo clippy --lib --all-features -- -D warnings` and `reuse lint` (1343/1343 files) all clean.

## Note on themes

I checked `ssg-themes.github.io` for a reusable theme first. None of its nine themes (`apex`, `atlas`, `kaishi`, `kinetic`, `lucid`, `quill`, `stablo`, `velocity`, `voxt`) is loadable by ssg as-is: all lack `template.html`, and only `atlas` has any `tera/` directory — containing just `base.html`. Making one usable is a separate piece of work; a minimal example should not depend on an external theme repo anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3PuhcVtzgYv55e7xE8A3X